### PR TITLE
update verySimpleFormatter to be consistent with TestInfo;

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -1022,7 +1022,7 @@ class Log<St> implements ActionObserver<St> {
     int dispatchCount,
     DateTime timestamp,
   ) =>
-      "$action ${ini ? 'INI' : 'FIM'}";
+      "$action ${ini ? 'INI' : 'END'}";
 
   /// A simple formatter that puts all data on one line.
   static String singleLineFormatter(


### PR DESCRIPTION
This uses `INI` or `END`
https://github.com/marcglasberg/async_redux/blob/07661d177777c825a6a96514d51866bacceea0be/lib/src/store.dart#L45

And this uses `INI` or `FIM` (which I think may be a typo for `FIN` as in finished)
https://github.com/marcglasberg/async_redux/blob/07661d177777c825a6a96514d51866bacceea0be/lib/src/store.dart#L1025

This PR is to make them consistent using `INI` and `END`.