### PR TITLE
[WIP] update observer handling order: action before, state, action after;

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -211,7 +211,7 @@ class Store<St> {
 
   /// Runs the action, applying its reducer, and possibly changing the store state.
   /// Note: store.dispatch is of type Dispatch.
-  void dispatch(ReduxAction<St> action) {
+  void dispatch(ReduxAction<St> action) async {
     _dispatchCount++;
     var afterWasRun = _Flag<bool>(false);
 
@@ -221,7 +221,7 @@ class Store<St> {
       }
 
     St stateIni = _state;
-    _processAction(action, afterWasRun);
+    await _processAction(action, afterWasRun);
     St stateEnd = _state;
 
     if (_stateObservers != null)
@@ -251,7 +251,7 @@ class Store<St> {
   /// We check the return type of methods `before` and `reduce` to decide if the
   /// reducer is synchronous or asynchronous. It's important to run the reducer
   /// synchronously, if possible.
-  void _processAction(ReduxAction<St> action, _Flag<bool> afterWasRun) async {
+  Future<void> _processAction(ReduxAction<St> action, _Flag<bool> afterWasRun) async {
     //
     // Creates the "INI" test snapshot.
     createTestInfoSnapshot(state, action, ini: true);


### PR DESCRIPTION
When trying to use the action observers and state observers at the same time, I noticed that the action and state observers run in this order:
- action observer, ini = true
- action observer, ini = false
- state observer

However, this was not quite intuitive to me. I was expecting the order to be:
- action observer, ini = true
- state observer
- action observer, ini = false

This PR is to update the handling of the observers to follow the second order.

---
I discovered this when trying to dispatch an action, that in turn dispatched an action in its `before` and `after` methods.

Here is a diagram of what I was doing.

![async_redux_observer_order_miro_board2](https://user-images.githubusercontent.com/8610039/63728995-8fdf6d00-c81a-11e9-9cfa-c745f9bf2e81.png)

This is the order of action and state observers currently:

![async_redux_observer_order](https://user-images.githubusercontent.com/8610039/63728730-86a1d080-c819-11e9-97f7-86374241d32f.png)

And this is what the order looks like after this PR:

![async_redux_observer_order_after_moving_action_observer](https://user-images.githubusercontent.com/8610039/63728760-a2a57200-c819-11e9-8bd6-d4892224e7ae.png)
