### PR TITLE
reverse order of changelog entries;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,73 +1,73 @@
-## [1.0.0] - 2019/08/05
+## [2.0.0] - 2019/09/17
 
-* Initial commit.
+* Breaking change: ErrorObserver API.
+* StoreTester parameter: shouldThrowUserExceptions (see <a href="https://github.com/marcglasberg/async_redux/issues/20">issue</a>).
 
-## [1.0.4] - 2019/08/05
+## [1.4.3] - 2019/09/15
 
-* Store tester.
+* Alternative: Use AsyncRedux with Provider (package provider_for_redux).
 
-## [1.0.9] - 2019/08/07
+## [1.4.1] - 2019/09/06
 
-* Error message improvement.
+* Flutter Awesome badge, and Pub badge.
 
-## [1.1.0] - 2019/08/07
+## [1.4.0] - 2019/09/02
 
-* Correct stacktrace for unwrapped action errors.
+* Fix: dispatchFuture getter in ReduxAction.
 
-## [1.1.1] - 2019/08/10
+## [1.3.9] - 2019/08/31
 
-* Ignore actions in the StoreTester.
-
-## [1.1.2] - 2019/08/13
-
-* README improvement.
-
-## [1.1.3] - 2019/08/21
-
-* StoreTester: waitCondition and waitConditionGetLast.
-
-## [1.2.0] - 2019/08/22
-
-* Doc improvement. StoreTester improvements.
-
-## [1.2.3] - 2019/08/23
-
-* StoreTester timeout message.
-
-## [1.3.3] - 2019/08/26
-
-* StoreConnector's converter and model parameters.
-
-## [1.3.5] - 2019/08/27
-
-* README improvement.
-
-## [1.3.7] - 2019/08/28
-
-* ModelObserver and DefaultModelObserver.
+* NavigateAction.navigatorKey getter.
 
 ## [1.3.8] - 2019/08/30
 
 * Alternatives to the Connector (StoreProvider static methods).
 * Waiting until an Action is finished (dispatchFuture).
 
-## [1.3.9] - 2019/08/31
+## [1.3.7] - 2019/08/28
 
-* NavigateAction.navigatorKey getter.
+* ModelObserver and DefaultModelObserver.
 
-## [1.4.0] - 2019/09/02
+## [1.3.5] - 2019/08/27
 
-* Fix: dispatchFuture getter in ReduxAction.
+* README improvement.
 
-## [1.4.1] - 2019/09/06
+## [1.3.3] - 2019/08/26
 
-* Flutter Awesome badge, and Pub badge.
+* StoreConnector's converter and model parameters.
 
-## [1.4.3] - 2019/09/15
+## [1.2.3] - 2019/08/23
 
-* Alternative: Use AsyncRedux with Provider (package provider_for_redux).
+* StoreTester timeout message.
 
-## [2.0.0] - 2019/09/17
+## [1.2.0] - 2019/08/22
 
-* Breaking change: ErrorObserver API.
-* StoreTester parameter: shouldThrowUserExceptions (see <a href="https://github.com/marcglasberg/async_redux/issues/20">issue</a>).
+* Doc improvement. StoreTester improvements.
+
+## [1.1.3] - 2019/08/21
+
+* StoreTester: waitCondition and waitConditionGetLast.
+
+## [1.1.2] - 2019/08/13
+
+* README improvement.
+
+## [1.1.1] - 2019/08/10
+
+* Ignore actions in the StoreTester.
+
+## [1.1.0] - 2019/08/07
+
+* Correct stacktrace for unwrapped action errors.
+
+## [1.0.9] - 2019/08/07
+
+* Error message improvement.
+
+## [1.0.4] - 2019/08/05
+
+* Store tester.
+
+## [1.0.0] - 2019/08/05
+
+* Initial commit.


### PR DESCRIPTION
This PR reverses the order of the change log to be newest to oldest (reference: https://keepachangelog.com/en/1.0.0/)

Please feel free to simply close this if you aren't interested in the change :+1: