### PR TITLE
Call observers only after _processAction finishes

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -319,7 +319,6 @@ class Store<St> {
 
   /// Runs the action, applying its reducer, and possibly changing the store state.
   /// Note: store.dispatch is of type Dispatch.
-
   void dispatch(ReduxAction<St> action) {
     if (_shutdown) return;
 

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -319,6 +319,7 @@ class Store<St> {
 
   /// Runs the action, applying its reducer, and possibly changing the store state.
   /// Note: store.dispatch is of type Dispatch.
+
   void dispatch(ReduxAction<St> action) {
     if (_shutdown) return;
 
@@ -330,15 +331,16 @@ class Store<St> {
       }
 
     St stateIni = _state;
-    _processAction(action);
-    St stateEnd = _state;
+    _processAction(action).then((_){
+      St stateEnd = _state;
 
-    if (_stateObservers != null)
-      for (StateObserver observer in _stateObservers) {
-        observer.observe(action, stateIni, stateEnd, dispatchCount);
-      }
+      if (_stateObservers != null)
+        for (StateObserver observer in _stateObservers) {
+          observer.observe(action, stateIni, stateEnd, dispatchCount);
+        }
 
-    if (_processPersistence != null) _processPersistence.process(action, stateEnd);
+      if (_processPersistence != null) _processPersistence.process(action, stateEnd);
+    });
   }
 
   Future<void> dispatchFuture(ReduxAction<St> action) async {

--- a/test/store_observer_test.dart
+++ b/test/store_observer_test.dart
@@ -24,7 +24,7 @@ class _MyAsyncAction extends ReduxAction<num> {
   }
 }
 
-class _MyStoreObserver extends StateObserver<num>{
+class _MyStateObserver extends StateObserver<num>{
   num iniValue;
   num endValue;
 
@@ -38,11 +38,11 @@ class _MyStoreObserver extends StateObserver<num>{
 
 void main() {
 
-  var observer = _MyStoreObserver();
+  var observer = _MyStateObserver();
   StoreTester<num> createStoreTester() {
     var store = Store<num>(
-      initialState: 0,
-      stateObservers: [observer]
+        initialState: 0,
+        stateObservers: [observer]
     );
     return StoreTester.from(store);
   }

--- a/test/store_observer_test.dart
+++ b/test/store_observer_test.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:async_redux/async_redux.dart';
+import "package:test/test.dart";
+
+class _MyAction extends ReduxAction<num> {
+  final num number;
+
+  _MyAction(this.number);
+
+  @override
+  FutureOr<num> reduce() => number;
+}
+
+class _MyAsyncAction extends ReduxAction<num> {
+  final num number;
+
+  _MyAsyncAction(this.number);
+
+  @override
+  FutureOr<num> reduce() async{
+    await Future.sync((){});
+    return number;
+  }
+}
+
+class _MyStoreObserver extends StateObserver<num>{
+  num iniValue;
+  num endValue;
+
+  @override
+  void observe(ReduxAction<num> action, num stateIni, num stateEnd, int dispatchCount) {
+    iniValue = stateIni;
+    endValue = stateEnd;
+  }
+
+}
+
+void main() {
+
+  var observer = _MyStoreObserver();
+  StoreTester<num> createStoreTester() {
+    var store = Store<num>(
+      initialState: 0,
+      stateObservers: [observer]
+    );
+    return StoreTester.from(store);
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+
+  test(
+      'Dispatch a sync action, see what the StateObserver picks up. ', () async {
+    var storeTester = createStoreTester();
+    expect(storeTester.state, 0);
+
+    storeTester.dispatch(_MyAction(1));
+    var condition = (TestInfo<num> info) => info.state == 1;
+    TestInfo<num> info1 = await storeTester.waitConditionGetLast(condition);
+    expect(observer.iniValue, 0);
+    expect(observer.endValue, 1);
+
+  });
+
+  ///////////////////////////////////////////////////////////////////////////////
+
+  test(
+      'Dispatch an async action, see what the StateObserver picks up.', () async {
+    var storeTester = createStoreTester();
+    expect(storeTester.state, 0);
+
+    storeTester.dispatch(_MyAsyncAction(1));
+    var condition = (TestInfo<num> info) => info.state == 1;
+    TestInfo<num> info2 = await storeTester.waitConditionGetLast(condition);
+    expect(observer.iniValue, 0);
+    expect(observer.endValue, 1);
+
+  });
+
+  ///////////////////////////////////////////////////////////////////////////////
+
+}


### PR DESCRIPTION
Suggested fix for #35 