### PR TITLE
PersistorPrinterDecorator: saveInitialState linked to the correct method

### DIFF
--- a/lib/src/persistor.dart
+++ b/lib/src/persistor.dart
@@ -81,7 +81,7 @@ class PersistorPrinterDecorator<T> extends Persistor<T> {
   @override
   Future<void> saveInitialState(state) async {
     print("Persistor: save initial state.");
-    return _persistor?.saveInitialState();
+    return _persistor?.saveInitialState(state);
   }
 
   @override

--- a/lib/src/persistor.dart
+++ b/lib/src/persistor.dart
@@ -81,7 +81,7 @@ class PersistorPrinterDecorator<T> extends Persistor<T> {
   @override
   Future<void> saveInitialState(state) async {
     print("Persistor: save initial state.");
-    return _persistor?.readState();
+    return _persistor?.saveInitialState();
   }
 
   @override


### PR DESCRIPTION
I guess it was for the copy paste.