### PR TITLE
fix 10 of 11 failing tests by ensuring initialization;

### DIFF
--- a/test/local_persist_test.dart
+++ b/test/local_persist_test.dart
@@ -3,11 +3,14 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
 import "package:test/test.dart";
 
 enum files { abc, xyz }
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
   /////////////////////////////////////////////////////////////////////////////
 
   test('Encode and decode state.', () async {


### PR DESCRIPTION
# Before change, there are 11 failing tests

00:02 +38 -1: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Save and load state. [E]                 
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 79:42           LocalPersist.save
  local_persist_test.dart 67:19                              main.<fn>
  
00:02 +38 -2: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Test file can be defined by String or enum. [E]
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  local_persist_test.dart 89:43                              main.<fn>
  
00:02 +38 -3: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Add objects to save, and load from file name. [E]
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 79:42           LocalPersist.save
  local_persist_test.dart 110:19                             main.<fn>
  
00:02 +38 -4: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Test appending, then loading. [E]        
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 79:42           LocalPersist.save
  local_persist_test.dart 137:19                             main.<fn>
  
00:02 +38 -5: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Test create, append, overwrite and delete the file. [E]
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 79:42           LocalPersist.save
  local_persist_test.dart 186:19                             main.<fn>
  
00:02 +38 -6: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Load/Length/Exists file that doesn't exist, or exists and is empty. [E]
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 95:42           LocalPersist.load
  local_persist_test.dart 213:26                             main.<fn>
  
00:02 +38 -7: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Deletes a file that exists or doesn't exist. [E]
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 130:42          LocalPersist.delete
  local_persist_test.dart 231:26                             main.<fn>
  
00:02 +38 -8: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Load as object. [E]                      
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 79:42           LocalPersist.save
  local_persist_test.dart 254:19                             main.<fn>
  
00:02 +39 -9: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Load many object as single object. [E]   
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 79:42           LocalPersist.save
  local_persist_test.dart 280:19                             main.<fn>
  
00:02 +39 -10: /Users/matthew/gadfly/forks/async_redux/test/local_persist_test.dart: Load as object (map) something which is not an object. [E]
  ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
  If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
  If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
  package:flutter/src/services/binary_messenger.dart 76:7    defaultBinaryMessenger.<fn>
  package:flutter/src/services/binary_messenger.dart 89:4    defaultBinaryMessenger
  package:flutter/src/services/platform_channel.dart 140:62  MethodChannel.binaryMessenger
  package:flutter/src/services/platform_channel.dart 314:35  MethodChannel.invokeMethod
  package:path_provider/path_provider.dart 92:22             getApplicationDocumentsDirectory
  package:async_redux/src/local_persist.dart 199:28          LocalPersist._findAppDocDir
  package:async_redux/src/local_persist.dart 175:37          LocalPersist.file
  package:async_redux/src/local_persist.dart 79:42           LocalPersist.save
  local_persist_test.dart 301:19                             main.<fn>
  
00:08 +76 -11: /Users/matthew/gadfly/forks/async_redux/test/persistence_test.dart: There is a 300 save duration, and no throttle. A first state change happens. A save starts immediately.A second state change happens 100 millis after the first. No other state changes happen. A second save will happen at 300 millis. This second save is necessary to save the second state change. [E]
  Expected: '(state:John, db: John)(state:1st, db: John)(state:1st, db: John)(state:2nd, db: John)(state:2nd, db: John)(state:2nd, db: John)(state:2nd, db: 1st)(state:2nd, db: 1st)(state:2nd, db: 2nd)'
    Actual: '(state:John, db: John)(state:1st, db: John)(state:1st, db: John)(state:2nd, db: John)(state:2nd, db: John)(state:2nd, db: John)(state:2nd, db: 1st)(state:2nd, db: 2nd)(state:2nd, db: 2nd)'
     Which: is different.
            Expected: ... :2nd, db: 1st)(state ...
              Actual: ... :2nd, db: 2nd)(state ...
                                    ^
             Differ at offset 163
  
  package:test_api             expect
  persistence_test.dart 381:5  main.<fn>

# After change, 10 of the 11 failing tests are resolved by the change in this PR
# Reference: https://github.com/flutter/flutter/issues/47033

00:06 +84 -1: /Users/matthew/gadfly/forks/async_redux/test/persistence_test.dart: There is no throttle. Each save takes 215 milliseconds. The state is changed each 60 milliseconds. Here we test that the initial state is persisted, and then that the state and the persistence occur when they should. [E]
  Expected: '(state:John, db: John)(state:0, db: John)(state:1, db: John)(state:2, db: John)(state:3, db: John)(state:4, db: 0)(state:5, db: 0)(state:6, db: 0)(state:7, db: 0)(state:8, db: 3)(state:9, db: 3)(state:10, db: 3)(state:11, db: 7)(state:12, db: 7)(state:13, db: 7)(state:14, db: 7)(state:15, db: 10)'
    Actual: '(state:John, db: John)(state:0, db: John)(state:1, db: John)(state:2, db: John)(state:3, db: John)(state:4, db: 0)(state:5, db: 0)(state:6, db: 0)(state:7, db: 0)(state:8, db: 3)(state:9, db: 3)(state:10, db: 3)(state:11, db: 7)(state:12, db: 7)(state:13, db: 7)(state:14, db: 7)(state:15, db: 11)'
     Which: is different.
            Expected: ... :15, db: 10)
              Actual: ... :15, db: 11)
                                    ^
             Differ at offset 295
  
  package:test_api             expect
  persistence_test.dart 238:5  main.<fn>

# Flutter Doctor

matthew@ ~/gadfly/forks/async_redux (master) $ flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, v1.12.13+hotfix.5, on Mac OS X 10.15.2 19C57, locale en-US)
[✓] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
[✓] Xcode - develop for iOS and macOS (Xcode 11.3.1)
[✓] Android Studio (version 3.4)
[✓] IntelliJ IDEA Community Edition (version 2019.3.3)
[✓] VS Code (version 1.41.1)
[!] Connected device
    ! No devices available

! Doctor found issues in 1 category.
