### PR TITLE
TodoAction should extend BaseAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,7 +1688,7 @@ Another thing you may do is creating more specialized **abstract** actions, that
 For example:
 
 ```dart
-abstract class TodoAction extends ReduxAction<AppState> {
+abstract class TodoAction extends BaseAction {
   
   TodoState reduceTodoState();
       


### PR DESCRIPTION
`TodoAction` should extend `BaseAction` instead of `ReduxAction<AppState>` or `AddTodoAction` won't have access to `todos`.

I think! (My first week of learning Dart so forgive me if I missed something!).