### PR TITLE
Fix wait-condition seeing action of previous test-infos

### DIFF
--- a/lib/src/store_tester.dart
+++ b/lib/src/store_tester.dart
@@ -163,8 +163,18 @@ class StoreTester<St> {
     TestInfoList<St> infoList = TestInfoList<St>();
 
     if (testImmediately) {
-      if (condition(_currentTestInfo)) {
-        infoList._add(_currentTestInfo);
+      var currentTestInfoWithoutAction = TestInfo<St>(
+        _currentTestInfo.state,
+        false,
+        null,
+        null,
+        null,
+        _currentTestInfo.dispatchCount,
+        _currentTestInfo.reduceCount,
+        _currentTestInfo.errors,
+      );
+      if (condition(currentTestInfoWithoutAction)) {
+        infoList._add(currentTestInfoWithoutAction);
         lastInfo = infoList.last;
         return infoList;
       }


### PR DESCRIPTION
There's a situation in which `StoreTester.waitCondition()` is able to see the `TestInfo.action` of a previous wait-condition when `testImmediately: true`. Take the following code as an example:

```dart
storeTester.dispatch(Action1());

await storeTester.waitCondition(
  (info) => (info.action is Action1),
  testImmediately: true,
);

await storeTester.waitCondition(
  (info) => (info.action is Action1) ? throw AssertionError() : true,
  testImmediately: true,
);
```

Previously, this code would throw an assertion error. This patch fixes that problem by making `info.action` be `null` when testing the condition immediately.