### PR TITLE
Ability to suppress state change events

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -14,9 +14,9 @@ import 'package:logging/logging.dart';
 
 // /////////////////////////////////////////////////////////////////////////////
 
-typedef Dispatch<St> = void Function(ReduxAction<St> action);
+typedef Dispatch<St> = void Function(ReduxAction<St> action, {bool notify});
 
-typedef DispatchFuture<St> = Future<void> Function(ReduxAction<St> action);
+typedef DispatchFuture<St> = Future<void> Function(ReduxAction<St> action, {bool notify});
 
 typedef TestInfoPrinter = void Function(TestInfo);
 

--- a/lib/src/store_tester.dart
+++ b/lib/src/store_tester.dart
@@ -36,6 +36,7 @@ class StoreTester<St> {
   final Store<St> _store;
   final List<Type> _ignore;
   StreamSubscription _subscription;
+  StreamSubscription _onChange;
   Completer<TestInfo<St>> _completer;
   Queue<Future<TestInfo<St>>> _futures;
 
@@ -107,7 +108,7 @@ class StoreTester<St> {
     _listen();
   }
 
-  void dispatch(ReduxAction<St> action) => store.dispatch(action);
+  void dispatch(ReduxAction<St> action, {bool notify = true}) => store.dispatch(action, notify: notify);
 
   Future<void> dispatchFuture(ReduxAction<St> action) => store.dispatchFuture(action);
 

--- a/test/store_tester_test.dart
+++ b/test/store_tester_test.dart
@@ -157,6 +157,44 @@ void main() {
 
   ///////////////////////////////////////////////////////////////////////////////
 
+  test('Dispatch multiple actions but only issue a single change event.', () async {
+    var storeTester = createStoreTester();
+    expect(storeTester.state.text, "0");
+
+    int invocations = 0;
+
+    storeTester.store.onChange.listen((event) {
+      invocations += 1;
+    });
+
+    await storeTester.dispatch(Action1());
+    await storeTester.dispatch(Action2());
+    await storeTester.dispatch(Action3());
+    await storeTester.dispatch(Action4());
+
+    expect(invocations, 4);
+    expect(storeTester.state.text, "0,1,2,3,4");
+
+    storeTester = createStoreTester();
+    expect(storeTester.state.text, "0");
+
+    invocations = 0;
+
+    storeTester.store.onChange.listen((event) {
+      invocations += 1;
+    });
+
+    await storeTester.dispatch(Action1(), notify: false);
+    await storeTester.dispatch(Action2(), notify: false);
+    await storeTester.dispatch(Action3(), notify: false);
+    await storeTester.dispatch(Action4(), notify: true);
+
+    expect(invocations, 1);
+    expect(storeTester.state.text, "0,1,2,3,4");
+  });
+
+  ///////////////////////////////////////////////////////////////////////////////
+
   test(
       'Dispatch some actions and wait until some condition is met. '
       'Get the end state.', () async {


### PR DESCRIPTION
I need a way to create an "aggregate" action, (a redux action, that delegates via dispatch to other actions) and only produce a single change event. Otherwise, I introduce a lot of onChange overhead to flutter widgets. Existing methods (eg: `reduceWithState`) cause mutation and throw safety away.

Practical use case is for listening to a universal URL and booting the app state for the first time (no persisted state), and wanting to bootstrap the entire UI via dispatches, before rending the first frame. Without this PR, there is a lot of jitteriness... 

The implementation was done in a backwards compatible way, but I would make the case that notify = false should be the default behavior when calling `dispatch`/`dispatchFuture` from within a `ReduxAction`.