### PR TITLE
Add optional parameter to NavigateAction.pop()

### DIFF
--- a/lib/src/navigate_action.dart
+++ b/lib/src/navigate_action.dart
@@ -62,7 +62,12 @@ class NavigateAction<St> extends ReduxAction<St> {
         predicate = null,
         arguments = null;
 
-  NavigateAction.pop() : this(null, navigateType: NavigateType.pop);
+  NavigateAction.pop([Object arguments])
+      : this(
+          null,
+          navigateType: NavigateType.pop,
+          arguments: arguments,
+        );
 
   NavigateAction.pushNamed(
     String routeName, {
@@ -116,7 +121,7 @@ class NavigateAction<St> extends ReduxAction<St> {
           break;
 
         case NavigateType.pop:
-          _navigatorKey.currentState.pop();
+          _navigatorKey.currentState.pop(arguments);
           break;
 
         case NavigateType.pushNamed:


### PR DESCRIPTION
This is a small change that allows a value to be returned via `NavigateAction.pop()`. The use case for me is returning true/false from the dialog opened by a Dismissible widget. Using application state for this does not seem appropriate in my case, so it's nice to have this option. Also, thank you for sharing this library. It's fantastic.