### PR TITLE
Dependency management via Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
   ```                                      
   class SaveAction extends ReduxAction<AppState, AppEnvironment> {      
-    Future<AppState> reduce({required AppEnvironment environment}) async {
+    Future<AppState> reduce() async {
 	  bool isSaved = await saveMyInfo(); 
       if (!isSaved) throw UserException("Save failed.");	 
 	  ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
   looks like this:
 
   ```                                      
-  class SaveAction extends ReduxAction<AppState> {      
-    Future<AppState> reduce() async {
+  class SaveAction extends ReduxAction<AppState, AppEnvironment> {      
+    Future<AppState> reduce({required AppEnvironment environment}) async {
 	  bool isSaved = await saveMyInfo(); 
       if (!isSaved) throw UserException("Save failed.");	 
 	  ...
@@ -192,7 +192,7 @@ This is a complete example:
 class MyHomePageConnector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, ViewModel>(
+    return StoreConnector<AppState, AppEnvironment, ViewModel>(
         vm: () => Factory(this),
         builder: (BuildContext context, ViewModel vm) =>
             MyHomePage(
@@ -202,7 +202,7 @@ class MyHomePageConnector extends StatelessWidget {
   }
 }
 
-class Factory extends VmFactory<AppState, MyHomePageConnector> {
+class Factory extends VmFactory<AppState, AppEnvironment, MyHomePageConnector> {
   Factory(widget) : super(widget);
 
   @override

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ database, and another action to change the state:
 class QueryAction extends ReduxAction<AppState, AppEnvironment> {
 
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     int value = await getAmount();
     dispatch(IncrementAction(amount: value));
     return null;
@@ -289,7 +289,7 @@ class IncrementAction extends ReduxAction<AppState, AppEnvironment> {
   IncrementAction({this.amount});
 
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     return state.copy(counter: state.counter + amount));
   }
 }
@@ -360,7 +360,7 @@ Complete example:
 class IncrementAndGetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
 
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
 	dispatch(IncrementAction());
 	String description = await read(Uri.http("numbersapi.com","${state.counter}");
 	return state.copy(description: description);
@@ -432,7 +432,7 @@ only if the save process succeeds. Your `SaveAction` may look like this:
 
 ```                                      
 class SaveAction extends ReduxAction<AppState, AppEnvironment> {      
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     bool isSaved = await saveMyInfo(); 
     if (!isSaved) throw UserException("Save failed.");	 
     ...
@@ -837,7 +837,7 @@ then deletes the database and sets the store to its initial state:
 ```
 class LogoutAction extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
 	await checkInternetConnection();
 	await deleteDatabase();
 	dispatch(NavigateToLoginScreenAction());
@@ -894,7 +894,7 @@ The solution is implementing the optional `wrapError(error)` method:
 class LogoutAction extends ReduxAction<AppState, AppEnvironment> {
 
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async { ... }
+  Future<AppState> reduce() async { ... }
 
   @override
   Object wrapError(error)
@@ -949,7 +949,7 @@ class SaveUserAction extends ReduxAction<AppState, AppEnvironment> {
    SaveUserAction(this.name);
 
    @override
-   Future<AppState> reduce({required AppEnvironment environment}) async {
+   Future<AppState> reduce() async {
 	 if (name.length < 4) dispatch(ShowDialogAction("Name must have at least 4 letters."));
 	 else await saveUser(name);
 	 return null;
@@ -969,7 +969,7 @@ class SaveUserAction extends ReduxAction<AppState, AppEnvironment> {
    SaveUserAction(this.name);
 
    @override
-   Future<AppState> reduce({required AppEnvironment environment}) async {
+   Future<AppState> reduce() async {
 	 if (name.length < 4) throw UserException("Name must have at least 4 letters.");
 	 await saveName(name);
 	 return null;
@@ -1316,11 +1316,11 @@ There are 5 different ways to define mocks:
     class MyAction extends ReduxAction<AppState, AppEnvironment> {
       String url;
       MyAction(this.url);
-      Future<AppState> reduce({required AppEnvironment environment}) => get(url);
+      Future<AppState> reduce() => get(url);
     }      
 
     class MyMockAction extends MockAction<AppState, AppEnvironment> {  
-      Future<AppState> reduce({required AppEnvironment environment}) async {                  
+      Future<AppState> reduce() async {                  
         String url = (action as MyAction).url;
         if (url == 'http://example.com') return 123;
         else if (url == 'http://flutter.io') return 345;
@@ -1341,11 +1341,11 @@ There are 5 different ways to define mocks:
     class MyAction extends ReduxAction<AppState, AppEnvironment> {
       String url;            
       MyAction(this.url);
-      Future<AppState> reduce({required AppEnvironment environment}) => get(url);
+      Future<AppState> reduce() => get(url);
     }
     
     class MyMockAction extends ReduxAction<AppState, AppEnvironment> {  
-      Future<AppState> reduce({required AppEnvironment environment}) async => 123;
+      Future<AppState> reduce() async => 123;
     }
     ```
 
@@ -1361,13 +1361,13 @@ There are 5 different ways to define mocks:
     class MyAction extends ReduxAction<AppState, AppEnvironment> {
       String url;        
       MyAction(this.url);
-      Future<AppState> reduce({required AppEnvironment environment}) => get(url);
+      Future<AppState> reduce() => get(url);
     }
     
     class MyMockAction extends MockAction<AppState, AppEnvironment> {
       String url;
       MyMockAction(this.url);  
-      Future<AppState> reduce({required AppEnvironment environment}) async {                     
+      Future<AppState> reduce() async {                     
         if (url == 'http://example.com') return 123;
         else if (url == 'http://flutter.io') return 345;
         else return 678;
@@ -1389,7 +1389,7 @@ There are 5 different ways to define mocks:
     class MyAction extends ReduxAction<AppState, AppEnvironment> {
       String url;        
       MyAction(this.url);
-      Future<AppState> reduce({required AppEnvironment environment}) => get(url);
+      Future<AppState> reduce() => get(url);
     }
     ```
 
@@ -1649,7 +1649,7 @@ class ViewModel extends BaseModel<AppState> {
 
 class ClearTextAction extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(changeTextEvt: Event());
+  AppState reduce() => state.copy(changeTextEvt: Event());
 }
 
 class ChangeTextAction extends ReduxAction<AppState, AppEnvironment> {
@@ -1657,7 +1657,7 @@ class ChangeTextAction extends ReduxAction<AppState, AppEnvironment> {
   ChangeTextAction(this.newText);
 
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(changeTextEvt: Event<String>(newText));
+  AppState reduce() => state.copy(changeTextEvt: Event<String>(newText));
 }
 ```
 
@@ -1846,7 +1846,7 @@ the `WaitAction`:
 ```
 class LoadAction extends ReduxAction<AppState, AppEnvironment> {
 
-  Future<AppState> reduce({required AppEnvironment environment}) async {    
+  Future<AppState> reduce() async {    
     var newText = await loadText(); 
     return state.copy(text: newText);
   }
@@ -1971,7 +1971,7 @@ class SaveAppointmentAction extends ReduxAction<AppState, AppEnvironment> {
   SaveAppointmentAction(this.appointment);      
 
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) {    
+  Future<AppState> reduce() {    
     dispatch(CreateCalendarIfNecessaryAction());    
     await store.waitCondition((state) => state.calendar != null);
     return state.copy(calendar: state.calendar.copyAdding(appointment));
@@ -2214,7 +2214,7 @@ class AddTodoAction extends ReduxAction<AppState, AppEnvironment> {
   AddTodoAction(this.todo);
 
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
 	if (todo == null) return null;
 	else return state.copy(todoState: List.of(state.todoState.todos)..add(todo));
   }
@@ -2245,7 +2245,7 @@ class AddTodoAction extends BaseAction {
   AddTodoAction(this.todo);
 
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
 	if (todo == null) return null;
 	else return state.copy(todoState: List.of(todos)..add(todo)));
   }
@@ -2264,7 +2264,7 @@ abstract class TodoAction extends BaseAction {
   TodoState reduceTodoState();
       
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) {
+  Future<AppState> reduce() {
     Future<TodoState> todoState = reduceTodoState();
     if (todoState is Future) return todoState.then((_todoState) => state.copy(todoState: _todoState));   
     else return (todoState == null) ? null : state.copy(todoState: todoState);
@@ -2309,7 +2309,7 @@ Then you could use it like this:
 class ChangeTextAction extends BarrierAction {
 
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
 	String newText = await read(Uri.http("numbersapi.com","${state.counter}");
 	return state.copy(
 	  counter: state.counter + 1,
@@ -2611,7 +2611,7 @@ This would be your reducer:
 
 ```
 @override
-Future<AppState> reduce({required AppEnvironment environment}) async {
+Future<AppState> reduce() async {
 	var something = await myDao.loadSomething();
 	return state.copy(something: something);
 }

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,13 @@ import 'package:flutter/material.dart';
 // Developed by Marcelo Glasberg (Aug 2019).
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-late Store<int> store;
+late Store<int, AppEnvironment> store;
+
+class AppEnvironment {
+  final int multiplier;
+
+  AppEnvironment({required this.multiplier});
+}
 
 /// This example shows a counter and a button.
 /// When the button is tapped, the counter will increment synchronously.
@@ -13,13 +19,13 @@ late Store<int> store;
 /// and thus the store is defined as `Store<int>`. The initial state is 0.
 ///
 void main() {
-  store = Store<int>(initialState: 0);
+  store = Store<int, AppEnvironment>(initialState: 0, environment: AppEnvironment(multiplier: 2));  
   runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => StoreProvider<int>(
+  Widget build(BuildContext context) => StoreProvider<int, AppEnvironment>(
       store: store,
       child: MaterialApp(
         home: MyHomePageConnector(),
@@ -29,13 +35,13 @@ class MyApp extends StatelessWidget {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// This action increments the counter by [amount]].
-class IncrementAction extends ReduxAction<int> {
+class IncrementAction extends ReduxAction<int, AppEnvironment> {
   final int amount;
 
   IncrementAction({required this.amount});
 
   @override
-  int reduce() => state + amount;
+  int reduce({required AppEnvironment environment}) => state + (amount * environment.multiplier);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -50,7 +56,7 @@ class MyHomePageConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<int, ViewModel>(
+    return StoreConnector<int, AppEnvironment, ViewModel>(
       vm: () => Factory(this),
       builder: (BuildContext context, ViewModel vm) => MyHomePage(
         counter: vm.counter,
@@ -61,7 +67,7 @@ class MyHomePageConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class Factory extends VmFactory<int, MyHomePageConnector> {
+class Factory extends VmFactory<int, AppEnvironment, MyHomePageConnector> {
   Factory(widget) : super(widget);
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,7 @@ class IncrementAction extends ReduxAction<int, AppEnvironment> {
   IncrementAction({required this.amount});
 
   @override
-  int reduce({required AppEnvironment environment}) => state + (amount * environment.multiplier);
+  int reduce() => state + (amount * environment.multiplier);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/lib/main_before_and_after.dart
+++ b/example/lib/main_before_and_after.dart
@@ -85,7 +85,7 @@ class IncrementAndGetDescriptionAction extends ReduxAction<AppState, AppEnvironm
   // Async reducer.
   // To make it async we simply return Future<AppState> instead of AppState.
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     // First, we increment the counter, synchronously.
     dispatch(IncrementAction(amount: 1));
 
@@ -116,7 +116,7 @@ class BarrierAction extends ReduxAction<AppState, AppEnvironment> {
   BarrierAction(this.waiting);
 
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     return state.copy(waiting: waiting);
   }
 }
@@ -131,7 +131,7 @@ class IncrementAction extends ReduxAction<AppState, AppEnvironment> {
 
   // Synchronous reducer.
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(counter: state.counter! + amount);
+  AppState reduce() => state.copy(counter: state.counter! + amount);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/lib/main_dispatch_future.dart
+++ b/example/lib/main_dispatch_future.dart
@@ -81,7 +81,7 @@ class MyApp extends StatelessWidget {
 
 class LoadMoreAction extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     Response response = await get(Uri.http(
         'http://numbersapi.com/',
         '${state.numTrivia!.length}'
@@ -103,7 +103,7 @@ class LoadMoreAction extends ReduxAction<AppState, AppEnvironment> {
 
 class RefreshAction extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     Response response = await get(Uri.http('http://numbersapi.com/', '0..19'));
     List<String> list = [];
     Map<String, dynamic> map = jsonDecode(response.body);
@@ -124,7 +124,7 @@ class IsLoadingAction extends ReduxAction<AppState, AppEnvironment> {
   final bool val;
 
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(isLoading: val);
+  AppState reduce() => state.copy(isLoading: val);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/lib/main_event_redux.dart
+++ b/example/lib/main_event_redux.dart
@@ -29,7 +29,10 @@ late Store<AppState, AppEnvironment> store;
 void main() {
   var state = AppState.initialState();
   var environment = AppEnvironment();
-  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
+  store = Store<AppState, AppEnvironment>(
+    initialState: state,
+    environment: environment,
+  );
   runApp(MyApp());
 }
 
@@ -98,7 +101,7 @@ class MyApp extends StatelessWidget {
 /// This action orders the text-controller to clear.
 class ClearTextAction extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(clearTextEvt: Event());
+  AppState reduce() => state.copy(clearTextEvt: Event());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -118,7 +121,7 @@ class _WaitAction extends ReduxAction<AppState, AppEnvironment> {
   _WaitAction(this.waiting);
 
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(waiting: waiting);
+  AppState reduce() => state.copy(waiting: waiting);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -127,8 +130,8 @@ class _WaitAction extends ReduxAction<AppState, AppEnvironment> {
 /// that tells the text-controller to display that new text.
 class ChangeTextAction extends BarrierAction {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
-    String newText = await read(Uri.http("numbersapi.com","${state.counter}"));
+  Future<AppState> reduce() async {
+    String newText = await read(Uri.http("numbersapi.com", "${state.counter}"));
     return state.copy(
       counter: state.counter! + 1,
       changeTextEvt: Event<String>(newText),
@@ -234,7 +237,8 @@ class _MyHomePageState extends State<MyHomePage> {
     String? newText = widget.changeTextEvt!.consume();
     if (newText != null)
       WidgetsBinding.instance!.addPostFrameCallback((_) {
-        if (mounted) controller!.value = controller!.value.copyWith(text: newText);
+        if (mounted)
+          controller!.value = controller!.value.copyWith(text: newText);
       });
   }
 
@@ -251,9 +255,11 @@ class _MyHomePageState extends State<MyHomePage> {
                 const Text('This is a TextField. Click to edit it:'),
                 TextField(controller: controller),
                 const SizedBox(height: 20),
-                FloatingActionButton(onPressed: widget.onChange, child: const Text("Change")),
+                FloatingActionButton(
+                    onPressed: widget.onChange, child: const Text("Change")),
                 const SizedBox(height: 20),
-                FloatingActionButton(onPressed: widget.onClear, child: const Text("Clear")),
+                FloatingActionButton(
+                    onPressed: widget.onClear, child: const Text("Clear")),
               ],
             ),
           ),

--- a/example/lib/main_increment_async.dart
+++ b/example/lib/main_increment_async.dart
@@ -21,7 +21,10 @@ late Store<AppState, AppEnvironment> store;
 void main() {
   var state = AppState.initialState();
   var environment = AppEnvironment();
-  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
+  store = Store<AppState, AppEnvironment>(
+    initialState: state,
+    environment: environment,
+  );
   runApp(MyApp());
 }
 
@@ -53,9 +56,7 @@ class AppState {
   int get hashCode => counter.hashCode ^ description.hashCode;
 }
 
-class AppEnvironment {
-
-}
+class AppEnvironment {}
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -72,17 +73,19 @@ class MyApp extends StatelessWidget {
 
 /// This action increments the counter by 1,
 /// and then gets some description text relating to the new counter number.
-class IncrementAndGetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
+class IncrementAndGetDescriptionAction
+    extends ReduxAction<AppState, AppEnvironment> {
   //
   // Async reducer.
   // To make it async we simply return Future<AppState> instead of AppState.
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     // First, we increment the counter, synchronously.
     dispatch(IncrementAction(amount: 1));
 
     // Then, we start and wait for some asynchronous process.
-    String description = await read(Uri.http("numbersapi.com","${state.counter}"));
+    String description =
+        await read(Uri.http("numbersapi.com", "${state.counter}"));
 
     // After we get the response, we can modify the state with it,
     // without having to dispatch another action.
@@ -100,7 +103,7 @@ class IncrementAction extends ReduxAction<AppState, AppEnvironment> {
 
   // Synchronous reducer.
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(counter: state.counter! + amount);
+  AppState reduce() => state.copy(counter: state.counter! + amount);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/lib/main_increment_async.dart
+++ b/example/lib/main_increment_async.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart';
 // Developed by Marcelo Glasberg (Aug 2019).
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-late Store<AppState> store;
+late Store<AppState, AppEnvironment> store;
 
 /// This example shows a counter, a text description, and a button.
 /// When the button is tapped, the counter will increment synchronously,
@@ -20,7 +20,8 @@ late Store<AppState> store;
 ///
 void main() {
   var state = AppState.initialState();
-  store = Store<AppState>(initialState: state);
+  var environment = AppEnvironment();
+  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
   runApp(MyApp());
 }
 
@@ -52,11 +53,15 @@ class AppState {
   int get hashCode => counter.hashCode ^ description.hashCode;
 }
 
+class AppEnvironment {
+
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => StoreProvider<AppState>(
+  Widget build(BuildContext context) => StoreProvider<AppState, AppEnvironment>(
       store: store,
       child: MaterialApp(
         home: MyHomePageConnector(),
@@ -67,12 +72,12 @@ class MyApp extends StatelessWidget {
 
 /// This action increments the counter by 1,
 /// and then gets some description text relating to the new counter number.
-class IncrementAndGetDescriptionAction extends ReduxAction<AppState> {
+class IncrementAndGetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
   //
   // Async reducer.
   // To make it async we simply return Future<AppState> instead of AppState.
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     // First, we increment the counter, synchronously.
     dispatch(IncrementAction(amount: 1));
 
@@ -88,14 +93,14 @@ class IncrementAndGetDescriptionAction extends ReduxAction<AppState> {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// This action increments the counter by [amount]].
-class IncrementAction extends ReduxAction<AppState> {
+class IncrementAction extends ReduxAction<AppState, AppEnvironment> {
   final int amount;
 
   IncrementAction({required this.amount});
 
   // Synchronous reducer.
   @override
-  AppState reduce() => state.copy(counter: state.counter! + amount);
+  AppState reduce({required AppEnvironment environment}) => state.copy(counter: state.counter! + amount);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -106,7 +111,7 @@ class MyHomePageConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, ViewModel>(
+    return StoreConnector<AppState, AppEnvironment, ViewModel>(
       vm: () => Factory(this),
       builder: (BuildContext context, ViewModel vm) => MyHomePage(
         counter: vm.counter,
@@ -118,7 +123,7 @@ class MyHomePageConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class Factory extends VmFactory<AppState, MyHomePageConnector> {
+class Factory extends VmFactory<AppState, AppEnvironment, MyHomePageConnector> {
   Factory(widget) : super(widget);
 
   @override

--- a/example/lib/main_navigate.dart
+++ b/example/lib/main_navigate.dart
@@ -2,13 +2,13 @@ import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-late Store<AppState> store;
+late Store<AppState, AppEnvironment> store;
 
 final navigatorKey = GlobalKey<NavigatorState>();
 
 void main() async {
   NavigateAction.setNavigatorKey(navigatorKey);
-  store = Store<AppState>(initialState: AppState());
+  store = Store<AppState, AppEnvironment>(initialState: AppState(), environment: AppEnvironment());
   runApp(MyApp());
 }
 
@@ -19,12 +19,14 @@ final routes = {
 
 class AppState {}
 
+class AppEnvironment {}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return StoreProvider<AppState>(
+    return StoreProvider<AppState, AppEnvironment>(
       store: store,
       child: MaterialApp(
         routes: routes,
@@ -58,7 +60,7 @@ class Page extends StatelessWidget {
 class Page1Connector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, ViewModel1>(
+    return StoreConnector<AppState, AppEnvironment, ViewModel1>(
       vm: () => Factory1(),
       builder: (BuildContext context, ViewModel1 vm) => Page(
         color: Colors.red,
@@ -70,7 +72,7 @@ class Page1Connector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class Factory1 extends VmFactory<AppState, Page1Connector> {
+class Factory1 extends VmFactory<AppState, AppEnvironment, Page1Connector> {
   @override
   ViewModel1 fromStore() =>
       ViewModel1(onChangePage: () => dispatch(NavigateAction.pushNamed("/myRoute")));
@@ -88,7 +90,7 @@ class ViewModel1 extends Vm {
 class Page2Connector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, ViewModel2>(
+    return StoreConnector<AppState, AppEnvironment, ViewModel2>(
       vm: () => Factory2(),
       builder: (BuildContext context, ViewModel2 vm) => Page(
         color: Colors.blue,
@@ -100,7 +102,7 @@ class Page2Connector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class Factory2 extends VmFactory<AppState, Page1Connector> {
+class Factory2 extends VmFactory<AppState, AppEnvironment, Page1Connector> {
   @override
   ViewModel2 fromStore() => ViewModel2(
         onChangePage: () => dispatch(NavigateAction.pop()),

--- a/example/lib/main_should_update_model.dart
+++ b/example/lib/main_should_update_model.dart
@@ -36,7 +36,7 @@ class IncrementAction extends ReduxAction<int, int> {
   IncrementAction({required this.amount});
 
   @override
-  int reduce({required int environment}) => state + amount;
+  int reduce() => state + amount;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/lib/main_should_update_model.dart
+++ b/example/lib/main_should_update_model.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 // Developed by Marcelo Glasberg (Aug 2019).
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-late Store<int> store;
+late Store<int, int> store;
 
 /// This example shows how to prevent creating view-models from invalid states.
 /// When the button is tapped, the counter will increment 5 times, synchronously.
@@ -14,13 +14,13 @@ late Store<int> store;
 /// Therefore, it will display 0, 4, 10, 14, 20, 24 etc.
 ///
 void main() {
-  store = Store<int>(initialState: 0);
+  store = Store<int, int>(initialState: 0, environment: 0);
   runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => StoreProvider<int>(
+  Widget build(BuildContext context) => StoreProvider<int, int>(
       store: store,
       child: MaterialApp(
         home: MyHomePageConnector(),
@@ -30,13 +30,13 @@ class MyApp extends StatelessWidget {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// This action increments the counter by [amount]].
-class IncrementAction extends ReduxAction<int> {
+class IncrementAction extends ReduxAction<int, int> {
   final int amount;
 
   IncrementAction({required this.amount});
 
   @override
-  int reduce() => state + amount;
+  int reduce({required int environment}) => state + amount;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -46,7 +46,7 @@ class MyHomePageConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<int, ViewModel>(
+    return StoreConnector<int, int, ViewModel>(
       vm: () => Factory(this),
       //
       // Should update the view-model only when the counter is even.
@@ -61,7 +61,7 @@ class MyHomePageConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class Factory extends VmFactory<int, MyHomePageConnector> {
+class Factory extends VmFactory<int, int, MyHomePageConnector> {
   Factory(widget) : super(widget);
 
   @override

--- a/example/lib/main_show_error_dialog.dart
+++ b/example/lib/main_show_error_dialog.dart
@@ -64,7 +64,7 @@ class SaveUserAction extends ReduxAction<AppState, AppEnvironment> {
   SaveUserAction(this.name);
 
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     print("Saving '$name'.");
     if (name.length < 4)
       throw const UserException("Name must have at least 4 letters.");

--- a/example/lib/main_show_error_dialog.dart
+++ b/example/lib/main_show_error_dialog.dart
@@ -4,14 +4,15 @@ import 'package:flutter/material.dart';
 // Developed by Marcelo Glasberg (Aug 2019).
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-late Store<AppState> store;
+late Store<AppState, AppEnvironment> store;
 
 /// This example lets you enter a name and click save.
 /// If the name has less than 4 chars, an error dialog will be shown.
 ///
 void main() {
   var state = AppState.initialState();
-  store = Store<AppState>(initialState: state);
+  var environment = AppEnvironment();
+  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
   runApp(MyApp());
 }
 
@@ -38,15 +39,17 @@ class AppState {
   int get hashCode => name.hashCode;
 }
 
+class AppEnvironment {}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /// To display errors, put the [UserExceptionDialog] below [StoreProvider] and [MaterialApp].
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => StoreProvider<AppState>(
+  Widget build(BuildContext context) => StoreProvider<AppState, AppEnvironment>(
         store: store,
         child: MaterialApp(
-          home: UserExceptionDialog<AppState>(
+          home: UserExceptionDialog<AppState, AppEnvironment>(
             child: MyHomePageConnector(),
           ),
         ),
@@ -55,13 +58,13 @@ class MyApp extends StatelessWidget {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-class SaveUserAction extends ReduxAction<AppState> {
+class SaveUserAction extends ReduxAction<AppState, AppEnvironment> {
   final String name;
 
   SaveUserAction(this.name);
 
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     print("Saving '$name'.");
     if (name.length < 4)
       throw const UserException("Name must have at least 4 letters.");
@@ -80,7 +83,7 @@ class MyHomePageConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, ViewModel>(
+    return StoreConnector<AppState, AppEnvironment, ViewModel>(
       vm: () => Factory(this),
       builder: (BuildContext context, ViewModel vm) => MyHomePage(
         name: vm.name,
@@ -91,7 +94,7 @@ class MyHomePageConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class Factory extends VmFactory<AppState, MyHomePageConnector> {
+class Factory extends VmFactory<AppState, AppEnvironment, MyHomePageConnector> {
   Factory(widget) : super(widget);
 
   @override

--- a/example/lib/main_static_view_model.dart
+++ b/example/lib/main_static_view_model.dart
@@ -40,7 +40,7 @@ class IncrementAction extends ReduxAction<int, int> {
   IncrementAction({required this.amount});
 
   @override
-  int reduce({required int environment}) => state + amount;
+  int reduce() => state + amount;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/lib/main_static_view_model.dart
+++ b/example/lib/main_static_view_model.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 // Developed by Marcelo Glasberg (Aug 2019).
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-late Store<int> store;
+late Store<int, int> store;
 
 /// This example shows how to use the same view-model architecture of the
 /// flutter_redux package. This is specially useful if you are migrating
@@ -18,13 +18,13 @@ late Store<int> store;
 /// `converter: (store) => ViewModel.fromStore(store)`.
 ///
 void main() {
-  store = Store<int>(initialState: 0);
+  store = Store<int, int>(initialState: 0, environment: 0);
   runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => StoreProvider<int>(
+  Widget build(BuildContext context) => StoreProvider<int, int>(
       store: store,
       child: MaterialApp(
         home: MyHomePageConnector(),
@@ -34,13 +34,13 @@ class MyApp extends StatelessWidget {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// This action increments the counter by [amount]].
-class IncrementAction extends ReduxAction<int> {
+class IncrementAction extends ReduxAction<int, int> {
   final int amount;
 
   IncrementAction({required this.amount});
 
   @override
-  int reduce() => state + amount;
+  int reduce({required int environment}) => state + amount;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -51,7 +51,7 @@ class MyHomePageConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<int, ViewModel>(
+    return StoreConnector<int, int, ViewModel>(
       converter: (store) => ViewModel.fromStore(store),
       builder: (BuildContext context, ViewModel vm) => MyHomePage(
         counter: vm.counter,
@@ -72,7 +72,7 @@ class ViewModel extends Vm {
   }) : super(equals: [counter]);
 
   /// Static factory called by the StoreConnector's converter parameter.
-  static ViewModel fromStore(Store<int> store) {
+  static ViewModel fromStore(Store<int, int> store) {
     return ViewModel(
       counter: store.state,
       onIncrement: () => store.dispatch(IncrementAction(amount: 1)),

--- a/example/lib/main_wait_action_advanced_1.dart
+++ b/example/lib/main_wait_action_advanced_1.dart
@@ -25,7 +25,7 @@ late Store<AppState, AppEnvironment> store;
 void main() {
   var state = AppState.initialState();
   var environment = AppEnvironment();
-  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
+  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment,);
   runApp(MyApp());
 }
 
@@ -84,7 +84,7 @@ class GetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
   GetDescriptionAction(this.index);
 
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     String description =
         await read(Uri.http("numbersapi.com", "$index"));
     await Future.delayed(const Duration(seconds: 2)); // Adds some more delay.

--- a/example/lib/main_wait_action_advanced_1.dart
+++ b/example/lib/main_wait_action_advanced_1.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart';
 // Developed by Marcelo Glasberg (Aug 2019).
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-late Store<AppState> store;
+late Store<AppState, AppEnvironment> store;
 
 /// This example shows how to use [WaitAction] in advanced ways.
 /// For this to work, the [AppState] must have a [wait] field of type [Wait],
@@ -24,7 +24,8 @@ late Store<AppState> store;
 ///
 void main() {
   var state = AppState.initialState();
-  store = Store<AppState>(initialState: state);
+  var environment = AppEnvironment();
+  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
   runApp(MyApp());
 }
 
@@ -62,11 +63,13 @@ class AppState {
   int get hashCode => descriptions.hashCode ^ wait.hashCode;
 }
 
+class AppEnvironment {}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => StoreProvider<AppState>(
+  Widget build(BuildContext context) => StoreProvider<AppState, AppEnvironment>(
       store: store,
       child: MaterialApp(
         home: MyHomePageConnector(),
@@ -75,13 +78,13 @@ class MyApp extends StatelessWidget {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-class GetDescriptionAction extends ReduxAction<AppState> {
+class GetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
   int index;
 
   GetDescriptionAction(this.index);
 
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     String description =
         await read(Uri.http("numbersapi.com", "$index"));
     await Future.delayed(const Duration(seconds: 2)); // Adds some more delay.
@@ -109,7 +112,7 @@ class MyHomePageConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, PageViewModel>(
+    return StoreConnector<AppState, AppEnvironment, PageViewModel>(
       vm: () => PageViewModelFactory(this),
       builder: (BuildContext context, PageViewModel vm) => MyHomePage(
         onGetDescription: vm.onGetDescription,
@@ -120,7 +123,7 @@ class MyHomePageConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class PageViewModelFactory extends VmFactory<AppState, MyHomePageConnector> {
+class PageViewModelFactory extends VmFactory<AppState, AppEnvironment, MyHomePageConnector> {
   PageViewModelFactory(widget) : super(widget);
 
   @override
@@ -157,7 +160,7 @@ class MyItemConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, ItemViewModel>(
+    return StoreConnector<AppState, AppEnvironment, ItemViewModel>(
       vm: () => ItemViewModelFactory(this),
       builder: (BuildContext context, ItemViewModel vm) => MyItem(
         description: vm.description,
@@ -170,7 +173,7 @@ class MyItemConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class ItemViewModelFactory extends VmFactory<AppState, MyItemConnector> {
+class ItemViewModelFactory extends VmFactory<AppState, AppEnvironment, MyItemConnector> {
   ItemViewModelFactory(widget) : super(widget);
 
   @override

--- a/example/lib/main_wait_action_advanced_2.dart
+++ b/example/lib/main_wait_action_advanced_2.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart';
 // Developed by Marcelo Glasberg (Aug 2019).
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-late Store<AppState> store;
+late Store<AppState, AppEnvironment> store;
 
 /// This example is the same as the one in `main_wait_action_advanced_1.dart`.
 /// However, instead of only using flags in the [WaitAction], it uses both
@@ -19,7 +19,8 @@ late Store<AppState> store;
 ///
 void main() {
   var state = AppState.initialState();
-  store = Store<AppState>(initialState: state);
+  var environment = AppEnvironment();
+  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
   runApp(MyApp());
 }
 
@@ -60,11 +61,13 @@ class AppState {
   int get hashCode => descriptions.hashCode ^ wait.hashCode;
 }
 
+class AppEnvironment {}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => StoreProvider<AppState>(
+  Widget build(BuildContext context) => StoreProvider<AppState, AppEnvironment>(
       store: store,
       child: MaterialApp(
         home: MyHomePageConnector(),
@@ -73,13 +76,13 @@ class MyApp extends StatelessWidget {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-class GetDescriptionAction extends ReduxAction<AppState> {
+class GetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
   int index;
 
   GetDescriptionAction(this.index);
 
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     String description =
         await read(Uri.http("numbersapi.com", "$index"));
     await Future.delayed(const Duration(seconds: 2)); // Adds some more delay.
@@ -107,7 +110,7 @@ class MyHomePageConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, PageViewModel>(
+    return StoreConnector<AppState, AppEnvironment, PageViewModel>(
       vm: () => PageViewModelFactory(this),
       builder: (BuildContext context, PageViewModel vm) => MyHomePage(
         onGetDescription: vm.onGetDescription,
@@ -118,7 +121,7 @@ class MyHomePageConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class PageViewModelFactory extends VmFactory<AppState, MyHomePageConnector> {
+class PageViewModelFactory extends VmFactory<AppState, AppEnvironment, MyHomePageConnector> {
   PageViewModelFactory(widget) : super(widget);
 
   @override
@@ -155,7 +158,7 @@ class MyItemConnector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<AppState, ItemViewModel>(
+    return StoreConnector<AppState, AppEnvironment, ItemViewModel>(
       vm: () => ItemViewModelFactory(this),
       builder: (BuildContext context, ItemViewModel vm) => MyItem(
         description: vm.description,
@@ -168,7 +171,7 @@ class MyItemConnector extends StatelessWidget {
 }
 
 /// Factory that creates a view-model for the StoreConnector.
-class ItemViewModelFactory extends VmFactory<AppState, MyItemConnector> {
+class ItemViewModelFactory extends VmFactory<AppState, AppEnvironment, MyItemConnector> {
   ItemViewModelFactory(widget) : super(widget);
 
   @override

--- a/example/lib/main_wait_action_advanced_2.dart
+++ b/example/lib/main_wait_action_advanced_2.dart
@@ -20,7 +20,7 @@ late Store<AppState, AppEnvironment> store;
 void main() {
   var state = AppState.initialState();
   var environment = AppEnvironment();
-  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
+  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment,);
   runApp(MyApp());
 }
 
@@ -82,7 +82,7 @@ class GetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
   GetDescriptionAction(this.index);
 
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     String description =
         await read(Uri.http("numbersapi.com", "$index"));
     await Future.delayed(const Duration(seconds: 2)); // Adds some more delay.

--- a/example/lib/main_wait_action_simple.dart
+++ b/example/lib/main_wait_action_simple.dart
@@ -40,7 +40,7 @@ late Store<AppState, AppEnvironment> store;
 void main() {
   var state = AppState.initialState();
   var environment = AppEnvironment();
-  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment);
+  store = Store<AppState, AppEnvironment>(initialState: state, environment: environment,);
   runApp(MyApp());
 }
 
@@ -98,7 +98,7 @@ class MyApp extends StatelessWidget {
 
 class IncrementAndGetDescriptionAction extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     dispatch(IncrementAction(amount: 1));
     String description =
         await read(Uri.http("numbersapi.com", "${state.counter}"));
@@ -124,7 +124,7 @@ class IncrementAction extends ReduxAction<AppState, AppEnvironment> {
   IncrementAction({required this.amount});
 
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(counter: state.counter! + amount);
+  AppState reduce() => state.copy(counter: state.counter! + amount);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/example/test/main_before_and_after_STATE_test.dart
+++ b/example/test/main_before_and_after_STATE_test.dart
@@ -14,7 +14,10 @@ void main() {
 
   test('Initial state.', () {
     //
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
 
     expect(storeTester.state.counter, 0);
     expect(storeTester.state.description, "");
@@ -25,11 +28,14 @@ void main() {
 
   test('Increment counter.', () async {
     //
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment()
+    );
     expect(storeTester.state.counter, 0);
 
     storeTester.dispatch(IncrementAction(amount: 1));
-    TestInfo<AppState> info = await storeTester.wait(IncrementAction);
+    TestInfo<AppState, AppEnvironment> info = await storeTester.wait(IncrementAction);
     expect(info.state.counter, 1);
 
     storeTester.dispatch(IncrementAction(amount: 5));
@@ -41,13 +47,16 @@ void main() {
 
   test('Increment counter and download description.', () async {
     //
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.counter, 0);
     expect(storeTester.state.description, isEmpty);
 
     storeTester.dispatch(IncrementAndGetDescriptionAction());
 
-    TestInfo<AppState> info = await storeTester.waitUntil(IncrementAndGetDescriptionAction);
+    TestInfo<AppState, AppEnvironment> info = await storeTester.waitUntil(IncrementAndGetDescriptionAction);
     expect(info.state.counter, 1);
     expect(info.state.description, isNotEmpty);
   });
@@ -56,11 +65,14 @@ void main() {
 
   test('Turn on/off the modal barrier.', () async {
     //
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.waiting, false);
 
     storeTester.dispatch(BarrierAction(true));
-    TestInfo<AppState> info = await storeTester.wait(BarrierAction);
+    TestInfo<AppState, AppEnvironment> info = await storeTester.wait(BarrierAction);
     expect(info.state.waiting, true);
 
     storeTester.dispatch(BarrierAction(false));
@@ -72,13 +84,16 @@ void main() {
 
   test('Modal barrier exists while downloading description.', () async {
     //
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment()
+    );
     expect(storeTester.state.counter, 0);
     expect(storeTester.state.description, isEmpty);
 
     storeTester.dispatch(IncrementAndGetDescriptionAction());
 
-    TestInfoList<AppState> infos = await storeTester.waitAll([
+    TestInfoList<AppState, AppEnvironment> infos = await storeTester.waitAll([
       IncrementAndGetDescriptionAction,
       BarrierAction,
       IncrementAction,

--- a/lib/src/action_observer.dart
+++ b/lib/src/action_observer.dart
@@ -5,11 +5,11 @@ import 'package:async_redux/async_redux.dart';
 // Uses code from package equatable by Felix Angelov.
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-abstract class ActionObserver<St> {
+abstract class ActionObserver<St, Environment> {
   /// If `ini==true` this is right before the action is dispatched.
   /// If `ini==false` this is right after the action finishes.
   void observe(
-    ReduxAction<St> action,
+    ReduxAction<St, Environment> action,
     int dispatchCount, {
     required bool ini,
   });

--- a/lib/src/error_observer.dart
+++ b/lib/src/error_observer.dart
@@ -13,12 +13,12 @@ import 'package:async_redux/async_redux.dart';
 /// Don't use the store to dispatch any actions, as this may have
 /// unpredictable results.
 ///
-abstract class ErrorObserver<St> {
+abstract class ErrorObserver<St, Environment> {
   bool observe(
     Object error,
     StackTrace stackTrace,
-    ReduxAction<St> action,
-    Store<St> store,
+    ReduxAction<St, Environment> action,
+    Store<St, Environment> store,
   );
 }
 
@@ -34,12 +34,12 @@ abstract class ErrorObserver<St> {
 ///
 /// `var store = Store(errorObserver:DevelopmentErrorObserver());`
 ///
-class DevelopmentErrorObserver<St> implements ErrorObserver<St> {
+class DevelopmentErrorObserver<St, Environment> implements ErrorObserver<St, Environment> {
   @override
   bool observe(
     Object error,
     StackTrace stackTrace,
-    ReduxAction<St> action,
+    ReduxAction<St, Environment> action,
     Store store,
   ) {
     if (error is UserException)
@@ -62,12 +62,12 @@ class DevelopmentErrorObserver<St> implements ErrorObserver<St> {
 ///
 /// `var store = Store(errorObserver:SwallowErrorObserver());`
 ///
-class SwallowErrorObserver<St> implements ErrorObserver<St> {
+class SwallowErrorObserver<St, Environment> implements ErrorObserver<St, Environment> {
   @override
   bool observe(
     Object error,
     StackTrace stackTrace,
-    ReduxAction<St> action,
+    ReduxAction<St, Environment> action,
     Store store,
   ) {
     return false;

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -39,7 +39,7 @@ import 'package:logging/logging.dart';
 ///       // Print them out (or do something more interesting!)
 ///       .listen((LogRecord) => print(LogRecord));
 ///
-class Log<St> implements ActionObserver<St> {
+class Log<St, Environment> implements ActionObserver<St, Environment> {
   //
   final Logger logger;
 
@@ -47,7 +47,7 @@ class Log<St> implements ActionObserver<St> {
   final Level level;
 
   /// A function that formats the String for printing
-  final MessageFormatter<St> formatter;
+  final MessageFormatter<St, Environment> formatter;
 
   /// Logs actions to the given Logger, and does not print anything to the console.
   Log({
@@ -60,7 +60,7 @@ class Log<St> implements ActionObserver<St> {
   factory Log.printer({
     Logger? logger,
     Level level = Level.INFO,
-    MessageFormatter<St> formatter = singleLineFormatter,
+    MessageFormatter<St, Environment> formatter = singleLineFormatter,
   }) {
     final log = Log(logger: logger, level: level, formatter: formatter);
     log.logger.onRecord //
@@ -106,7 +106,7 @@ class Log<St> implements ActionObserver<St> {
   }
 
   @override
-  void observe(ReduxAction<St> action, int dispatchCount, {required bool ini}) {
+  void observe(ReduxAction<St, Environment> action, int dispatchCount, {required bool ini}) {
     logger.log(
       level,
       formatter(null, action, ini, dispatchCount, new DateTime.now()),
@@ -121,9 +121,9 @@ class Log<St> implements ActionObserver<St> {
 ///   final log = Log(formatter: onlyLogActionFormatter);
 ///   var store = new Store(initialState: 0, actionObservers:[log], stateObservers: [...]);
 ///
-typedef MessageFormatter<St> = String Function(
+typedef MessageFormatter<St, Environment> = String Function(
   St? state,
-  ReduxAction<St> action,
+  ReduxAction<St, Environment> action,
   bool ini,
   int dispatchCount,
   DateTime timestamp,

--- a/lib/src/mock_store.dart
+++ b/lib/src/mock_store.dart
@@ -13,9 +13,10 @@ import 'package:async_redux/async_redux.dart';
 ///
 /// For more info, see: https://pub.dartlang.org/packages/async_redux
 ///
-class MockStore<St> extends Store<St> {
+class MockStore<St, Environment> extends Store<St, Environment> {
   MockStore({
     required St initialState,
+    required Environment environment,
     bool syncStream = false,
     TestInfoPrinter? testInfoPrinter,
     List<ActionObserver>? actionObservers,
@@ -28,6 +29,7 @@ class MockStore<St> extends Store<St> {
     this.mocks,
   }) : super(
           initialState: initialState,
+          environment: environment,
           syncStream: syncStream,
           testInfoPrinter: testInfoPrinter,
           actionObservers: actionObservers,
@@ -54,27 +56,27 @@ class MockStore<St> extends Store<St> {
   ///
   Map<Type, dynamic>? mocks;
 
-  MockStore<St> addMock(Type actionType, dynamic mock) {
+  MockStore<St, Environment> addMock(Type actionType, dynamic mock) {
     (mocks ??= {})[actionType] = mock;
     return this;
   }
 
-  MockStore<St> addMocks(Map<Type, dynamic> mocks) {
+  MockStore<St, Environment> addMocks(Map<Type, dynamic> mocks) {
     (this.mocks ??= {}).addAll(mocks);
     return this;
   }
 
-  MockStore<St> clearMocks() {
+  MockStore<St, Environment> clearMocks() {
     mocks = null;
     return this;
   }
 
   @override
   Future<ActionStatus> dispatch(
-    ReduxAction<St> action, {
+    ReduxAction<St, Environment> action, {
     bool notify = true,
   }) {
-    ReduxAction<St>? _action = _getMockedAction(action);
+    ReduxAction<St, Environment>? _action = _getMockedAction(action);
 
     if (_action == null)
       return Future.value(ActionStatus());
@@ -82,7 +84,7 @@ class MockStore<St> extends Store<St> {
       return super.dispatch(_action, notify: notify);
   }
 
-  ReduxAction<St>? _getMockedAction(ReduxAction<St> action) {
+  ReduxAction<St, Environment>? _getMockedAction(ReduxAction<St, Environment> action) {
     if (mocks == null || !mocks!.containsKey(action.runtimeType))
       return action;
     else {
@@ -92,33 +94,33 @@ class MockStore<St> extends Store<St> {
       if (mock == null)
         return null;
       //
-      // 2) A `MockAction<St>` instance to dispatch that action instead,
+      // 2) A `MockAction<St, Environment>` instance to dispatch that action instead,
       // and provide the original action as a getter to the mocked action.
-      else if (mock is MockAction<St>) {
+      else if (mock is MockAction<St, Environment>) {
         mock._setAction(action);
         return mock;
       }
       //
-      // 3) A `ReduxAction<St>` instance to dispatch that mocked action instead.
+      // 3) A `ReduxAction<St, Environment>` instance to dispatch that mocked action instead.
       else if (mock is ReduxAction) {
-        return mock as ReduxAction<St>;
+        return mock as ReduxAction<St, Environment>;
       }
       //
-      // 4) `ReduxAction<St> Function(ReduxAction<St>)` to create a mock
+      // 4) `ReduxAction<St> Function(ReduxAction<St, Environment>)` to create a mock
       // from the original action.
-      else if (mock is ReduxAction<St> Function(ReduxAction<St>)) {
-        ReduxAction<St> mockAction = mock(action);
+      else if (mock is ReduxAction<St, Environment> Function(ReduxAction<St, Environment>)) {
+        ReduxAction<St, Environment> mockAction = mock(action);
         return mockAction;
       }
       //
       // 5) `St Function(ReduxAction<St>, St)` or
       // `Future<St> Function(ReduxAction<St>, St)` to modify the state directly.
-      else if (mock is St Function(ReduxAction<St>, St)) {
-        MockAction<St> mockAction = _GeneralActionSync(mock);
+      else if (mock is St Function(ReduxAction<St, Environment>, St, Environment)) {
+        MockAction<St, Environment> mockAction = _GeneralActionSync(mock);
         mockAction._setAction(action);
         return mockAction;
-      } else if (mock is Future<St> Function(ReduxAction<St>, St)) {
-        MockAction<St> mockAction = _GeneralActionAsync(mock);
+      } else if (mock is Future<St> Function(ReduxAction<St, Environment>, St, Environment)) {
+        MockAction<St, Environment> mockAction = _GeneralActionAsync(mock);
         mockAction._setAction(action);
         return mockAction;
       }
@@ -129,46 +131,46 @@ class MockStore<St> extends Store<St> {
             "`${mock.runtimeType}`.\n"
             "Valid mock types are:\n"
             "`null`\n"
-            "`MockAction<St>`\n"
-            "`ReduxAction<St>`\n"
-            "`ReduxAction<St> Function(ReduxAction<St>)`\n"
-            "`St Function(ReduxAction<St>, St)`\n");
+            "`MockAction<St, Environment>`\n"
+            "`ReduxAction<St, Environment>`\n"
+            "`ReduxAction<St, Environment> Function(ReduxAction<St, Environment>)`\n"
+            "`St Function(ReduxAction<St, Environment>, St)`\n");
     }
   }
 }
 
 // /////////////////////////////////////////////////////////////////////////////
 
-abstract class MockAction<St> extends ReduxAction<St> {
-  late ReduxAction<St> _action;
+abstract class MockAction<St, Environment> extends ReduxAction<St, Environment> {
+  late ReduxAction<St, Environment> _action;
 
-  ReduxAction<St> get action => _action;
+  ReduxAction<St, Environment> get action => _action;
 
-  void _setAction(ReduxAction<St> action) {
+  void _setAction(ReduxAction<St, Environment> action) {
     _action = action;
   }
 }
 
 // /////////////////////////////////////////////////////////////////////////////
 
-class _GeneralActionSync<St> extends MockAction<St> {
-  final St Function(ReduxAction<St> action, St state) _reducer;
+class _GeneralActionSync<St, Environment> extends MockAction<St, Environment> {
+  final St Function(ReduxAction<St, Environment> action, St state, Environment environment) _reducer;
 
   _GeneralActionSync(this._reducer);
 
   @override
-  St reduce() => _reducer(action, state);
+  St reduce({required Environment environment}) => _reducer(action, state, environment);
 }
 
 // /////////////////////////////////////////////////////////////////////////////
 
-class _GeneralActionAsync<St> extends MockAction<St> {
-  final Future<St> Function(ReduxAction<St> action, St state) _reducer;
+class _GeneralActionAsync<St, Environment> extends MockAction<St, Environment> {
+  final Future<St> Function(ReduxAction<St, Environment> action, St state, Environment environment) _reducer;
 
   _GeneralActionAsync(this._reducer);
 
   @override
-  Future<St> reduce() => _reducer(action, state);
+  Future<St> reduce({required Environment environment}) => _reducer(action, state, environment);
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/lib/src/mock_store.dart
+++ b/lib/src/mock_store.dart
@@ -115,7 +115,7 @@ class MockStore<St, Environment> extends Store<St, Environment> {
       //
       // 5) `St Function(ReduxAction<St>, St)` or
       // `Future<St> Function(ReduxAction<St>, St)` to modify the state directly.
-      else if (mock is St Function(ReduxAction<St, Environment>, St, Environment)) {
+      else if (mock is St Function(ReduxAction<St, Environment>, St)) {
         MockAction<St, Environment> mockAction = _GeneralActionSync(mock);
         mockAction._setAction(action);
         return mockAction;
@@ -154,12 +154,12 @@ abstract class MockAction<St, Environment> extends ReduxAction<St, Environment> 
 // /////////////////////////////////////////////////////////////////////////////
 
 class _GeneralActionSync<St, Environment> extends MockAction<St, Environment> {
-  final St Function(ReduxAction<St, Environment> action, St state, Environment environment) _reducer;
+  final St Function(ReduxAction<St, Environment> action, St state) _reducer;
 
   _GeneralActionSync(this._reducer);
 
   @override
-  St reduce({required Environment environment}) => _reducer(action, state, environment);
+  St reduce() => _reducer(action, state);
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -170,7 +170,7 @@ class _GeneralActionAsync<St, Environment> extends MockAction<St, Environment> {
   _GeneralActionAsync(this._reducer);
 
   @override
-  Future<St> reduce({required Environment environment}) => _reducer(action, state, environment);
+  Future<St> reduce() => _reducer(action, state, environment);
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/lib/src/navigate_action.dart
+++ b/lib/src/navigate_action.dart
@@ -51,7 +51,7 @@ class NavigateAction<St, Environment> extends ReduxAction<St, Environment> {
   NavigateType get type => details.type;
 
   @override
-  St? reduce({required Environment environment}) {
+  St? reduce() {
     details.navigate();
     return null;
   }

--- a/lib/src/navigate_action.dart
+++ b/lib/src/navigate_action.dart
@@ -23,7 +23,7 @@ import '../async_redux.dart';
 /// `NavigateAction.popUntilRouteName()`,
 /// `NavigateAction.popUntilRoute()`,
 ///
-class NavigateAction<St> extends ReduxAction<St> {
+class NavigateAction<St, Environment> extends ReduxAction<St, Environment> {
   static GlobalKey<NavigatorState>? _navigatorKey;
 
   static GlobalKey<NavigatorState>? get navigatorKey => _navigatorKey;
@@ -51,7 +51,7 @@ class NavigateAction<St> extends ReduxAction<St> {
   NavigateType get type => details.type;
 
   @override
-  St? reduce() {
+  St? reduce({required Environment environment}) {
     details.navigate();
     return null;
   }

--- a/lib/src/persistor.dart
+++ b/lib/src/persistor.dart
@@ -138,7 +138,7 @@ class PersistException implements Exception {
 
 class PersistAction<St, Environment> extends ReduxAction<St, Environment> {
   @override
-  St? reduce({required Environment environment}) => null;
+  St? reduce() => null;
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/lib/src/persistor.dart
+++ b/lib/src/persistor.dart
@@ -20,7 +20,7 @@ import 'package:async_redux/async_redux.dart';
 /// await persistor.saveInitialState(initialState);
 /// }
 ///
-/// var store = Store<AppState>(
+/// var store = Store<AppState, AppEnvironment>(
 ///   initialState: initialState,
 ///   persistor: persistor,
 /// );
@@ -49,7 +49,7 @@ abstract class Persistor<St> {
 /// Use it like this:
 ///
 /// ```dart
-/// var store = Store<AppState>(...,  persistor: PersistorPrinterDecorator(persistor));
+/// var store = Store<AppState, AppEnvironment>(...,  persistor: PersistorPrinterDecorator(persistor));
 /// ```
 ///
 class PersistorPrinterDecorator<St> extends Persistor<St> {
@@ -136,9 +136,9 @@ class PersistException implements Exception {
 
 // /////////////////////////////////////////////////////////////////////////////
 
-class PersistAction<St> extends ReduxAction<St> {
+class PersistAction<St, Environment> extends ReduxAction<St, Environment> {
   @override
-  St? reduce() => null;
+  St? reduce({required Environment environment}) => null;
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/lib/src/process_persistence.dart
+++ b/lib/src/process_persistence.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:async_redux/async_redux.dart';
 
-class ProcessPersistence<St> {
+class ProcessPersistence<St, Environment> {
   //
   ProcessPersistence(this.persistor)
       : isPersisting = false,
@@ -20,7 +20,7 @@ class ProcessPersistence<St> {
   Duration get throttle => persistor.throttle ?? const Duration();
 
   void process(
-    ReduxAction<St>? action,
+    ReduxAction<St, Environment>? action,
     St newState,
   ) {
     newestState = newState;

--- a/lib/src/redux_action.dart
+++ b/lib/src/redux_action.dart
@@ -22,6 +22,8 @@ abstract class ReduxAction<St, Environment> {
 
   St get state => _store.state;
 
+  Environment get environment => _store.environment;
+
   /// Returns true only if the action finished with no errors.
   /// In other words, if the methods before, reduce and after all finished executing
   /// without throwing any errors.
@@ -58,7 +60,7 @@ abstract class ReduxAction<St, Environment> {
   /// The `StoreConnector`s may rebuild only if the `reduce` method returns
   /// a state which is both not `null` and different from the previous one
   /// (comparing by `identical`, not `equals`).
-  FutureOr<St?> reduce({required Environment environment});
+  FutureOr<St?> reduce();
 
   /// You may wrap the reducer to allow for some pre or post-processing.
   /// For example, if you want to abort an async reducer if the state
@@ -106,7 +108,7 @@ abstract class ReduxAction<St, Environment> {
   FutureOr<St?> reduceWithState(Store<St, Environment> store, St state) {
     setStore(store);
     _store.defineState(state);
-    return reduce(environment: store.environment);
+    return reduce();
   }
 
   @override

--- a/lib/src/state_observer.dart
+++ b/lib/src/state_observer.dart
@@ -5,9 +5,9 @@ import 'package:async_redux/async_redux.dart';
 // Uses code from package equatable by Felix Angelov.
 // For more info, see: https://pub.dartlang.org/packages/async_redux
 
-abstract class StateObserver<St> {
+abstract class StateObserver<St, Environment> {
   void observe(
-    ReduxAction<St> action,
+    ReduxAction<St, Environment> action,
     St stateIni,
     St stateEnd,
     int dispatchCount,

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -15,7 +15,7 @@ part 'redux_action.dart';
 
 // /////////////////////////////////////////////////////////////////////////////
 
-typedef Reducer<St, Environment> = FutureOr<St?> Function({required Environment environment});
+typedef Reducer<St, Environment> = FutureOr<St?> Function();
 
 typedef Dispatch<St, Environment> = Future<ActionStatus> Function(
   ReduxAction<St, Environment> action, {
@@ -29,11 +29,11 @@ typedef Dispatch<St, Environment> = Future<ActionStatus> Function(
 /// The only way to change the state in the store is to dispatch a ReduxAction.
 /// You may implement these methods:
 ///
-/// 1) `AppState reduce({required AppEnvironment environment})` ➜
+/// 1) `AppState reduce()` ➜
 ///    To run synchronously, just return the state:
-///         AppState reduce({required AppEnvironment environment}) { ... return state; }
+///         AppState reduce() { ... return state; }
 ///    To run asynchronously, return a future of the state:
-///         Future<AppState> reduce({required AppEnvironment environment}) async { ... return state; }
+///         Future<AppState> reduce() async { ... return state; }
 ///    Note that changing the state is optional. If you return null (or Future of null)
 ///    the state will not be changed. Just the same, if you return the same instance
 ///    of state (or its Future) the state will not be changed.
@@ -368,17 +368,17 @@ class Store<St, Environment> {
     Reducer<St?, Environment> reducer = action.wrapReduce(action.reduce);
 
     // Sync reducer.
-    if (reducer is St? Function({required Environment environment})) {
-      St? result = reducer(environment: environment);
+    if (reducer is St? Function()) {
+      St? result = reducer();
       _registerState(result, action, notify: notify);
     }
     //
     // Async reducer.
-    else if (reducer is Future<St?> Function({required Environment environment})) {
+    else if (reducer is Future<St?> Function()) {
       // Make sure it's NOT a completed future.
       Future<St?> result = (() async {
         await Future.microtask(() {});
-        return reducer(environment: environment);
+        return reducer();
       })();
 
       // The "then callback" will be applied synchronously,

--- a/lib/src/store_provider.dart
+++ b/lib/src/store_provider.dart
@@ -11,23 +11,23 @@ import 'package:flutter/material.dart';
 /// Provides a Redux [Store] to all ancestors of this Widget.
 /// This should generally be a root widget in your App.
 /// Connect to the Store provided by this Widget using a [StoreConnector].
-class StoreProvider<St> extends InheritedWidget {
-  final Store<St> _store;
+class StoreProvider<St, Environment> extends InheritedWidget {
+  final Store<St, Environment> _store;
 
   const StoreProvider({
     Key? key,
-    required Store<St> store,
+    required Store<St, Environment> store,
     required Widget child,
   })  : _store = store,
         super(key: key, child: child);
 
-  static Store<St> of<St>(BuildContext context, Object? debug) {
-    final StoreProvider<St>? provider =
-        context.dependOnInheritedWidgetOfExactType<StoreProvider<St>>();
+  static Store<St, Environment> of<St, Environment>(BuildContext context, Object? debug) {
+    final StoreProvider<St, Environment>? provider =
+        context.dependOnInheritedWidgetOfExactType<StoreProvider<St, Environment>>();
 
     if (provider == null)
       throw StoreConnectorError(
-        _typeOf<StoreProvider<St>>(),
+        _typeOf<StoreProvider<St, Environment>>(),
         debug,
       );
 
@@ -36,22 +36,22 @@ class StoreProvider<St> extends InheritedWidget {
 
   /// Dispatch an action without a StoreConnector,
   /// and get a `Future<void>` which completes when the action is done.
-  static FutureOr<ActionStatus> dispatch<St>(
+  static FutureOr<ActionStatus> dispatch<St, Environment>(
     BuildContext context,
-    ReduxAction<St> action, {
+    ReduxAction<St, Environment> action, {
     Object? debug,
   }) =>
-      of<St>(context, debug).dispatch(action);
+      of<St, Environment>(context, debug).dispatch(action);
 
   /// Get the state, without a StoreConnector.
-  static St? state<St>(BuildContext context, {Object? debug}) => //
-      of<St>(context, debug).state;
+  static St? state<St, Environment>(BuildContext context, {Object? debug}) => //
+      of<St, Environment>(context, debug).state;
 
   /// Workaround to capture generics.
   static Type _typeOf<T>() => T;
 
   @override
-  bool updateShouldNotify(StoreProvider<St> oldWidget) => //
+  bool updateShouldNotify(StoreProvider<St, Environment> oldWidget) => //
       _store != oldWidget._store;
 }
 

--- a/lib/src/store_tester.dart
+++ b/lib/src/store_tester.dart
@@ -789,7 +789,7 @@ class _NewStateAction<St, Environment> extends ReduxAction<St, Environment> {
   _NewStateAction(this.newState);
 
   @override
-  St reduce({required Environment environment}) => newState;
+  St reduce() => newState;
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/lib/src/test_info.dart
+++ b/lib/src/test_info.dart
@@ -4,10 +4,11 @@ import 'package:async_redux/async_redux.dart';
 
 typedef TestInfoPrinter = void Function(TestInfo);
 
-class TestInfo<St> {
+class TestInfo<St, Environment> {
   final St state;
+  final Environment environment;
   final bool ini;
-  final ReduxAction<St>? action;
+  final ReduxAction<St, Environment>? action;
   final int dispatchCount;
   final int reduceCount;
 
@@ -49,6 +50,7 @@ class TestInfo<St> {
 
   TestInfo(
     this.state,
+    this.environment,
     this.ini,
     this.action,
     this.error,

--- a/lib/src/user_exception.dart
+++ b/lib/src/user_exception.dart
@@ -197,7 +197,7 @@ abstract class ExceptionCode {
 /// should not throw an exception, but instead call the [UserExceptionAction],
 /// which will then simply throw the exception in its `reduce` method.
 ///
-class UserExceptionAction<St> extends ReduxAction<St> {
+class UserExceptionAction<St, Environment> extends ReduxAction<St, Environment> {
   final UserException exception;
 
   UserExceptionAction(
@@ -216,7 +216,7 @@ class UserExceptionAction<St> extends ReduxAction<St> {
   UserExceptionAction.from(this.exception);
 
   @override
-  Future<St> reduce() async => throw exception;
+  Future<St> reduce({required Environment environment}) async => throw exception;
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/lib/src/user_exception.dart
+++ b/lib/src/user_exception.dart
@@ -216,7 +216,7 @@ class UserExceptionAction<St, Environment> extends ReduxAction<St, Environment> 
   UserExceptionAction.from(this.exception);
 
   @override
-  Future<St> reduce({required Environment environment}) async => throw exception;
+  Future<St> reduce() async => throw exception;
 }
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/lib/src/user_exception_dialog.dart
+++ b/lib/src/user_exception_dialog.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 /// class MyApp extends StatelessWidget {
 ///   @override
 ///   Widget build(BuildContext context)
-///     => StoreProvider<AppState>(
+///     => StoreProvider<AppState, AppEnvironment>(
 ///       store: store,
 ///       child: MaterialApp(
 ///           home: UserExceptionDialog<AppState>(
@@ -24,7 +24,7 @@ import 'package:flutter/material.dart';
 ///
 /// For more info, see: https://pub.dartlang.org/packages/async_redux
 ///
-class UserExceptionDialog<St> extends StatelessWidget {
+class UserExceptionDialog<St, Environment> extends StatelessWidget {
   final Widget child;
   final ShowUserExceptionDialog? onShowUserExceptionDialog;
 
@@ -48,7 +48,7 @@ class UserExceptionDialog<St> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StoreConnector<St, _ViewModel>(
+    return StoreConnector<St, Environment, _ViewModel>(
       model: _ViewModel(),
       builder: (context, vm) {
         //

--- a/lib/src/view_model.dart
+++ b/lib/src/view_model.dart
@@ -140,7 +140,7 @@ abstract class Vm {
 ///      builder: ...
 ///
 /// ...
-/// class _Factory extends VmFactory<AppState, MyHomePageConnector> {
+/// class _Factory extends VmFactory<AppState, AppEnvironment, MyHomePageConnector> {
 ///    _Factory(widget) : super(widget);
 ///    _ViewModel fromStore() => _ViewModel(
 ///        counter: state,
@@ -148,13 +148,13 @@ abstract class Vm {
 /// }
 /// ```
 ///
-abstract class VmFactory<St, T> {
+abstract class VmFactory<St, Environment, T> {
   /// A reference to the connector widget that will instantiate the view-model.
   final T? widget;
 
-  late final Store<St> _store;
+  late final Store<St, Environment> _store;
   late final St _state;
-  late final Dispatch<St> _dispatch;
+  late final Dispatch<St, Environment> _dispatch;
   late final UserException? Function() _getAndRemoveFirstError;
 
   /// You need to pass the connector widget only if the view-model needs any info from it.
@@ -163,7 +163,7 @@ abstract class VmFactory<St, T> {
   Vm fromStore();
 
   void _setStore(St state, Store store) {
-    _store = store as Store<St>;
+    _store = store as Store<St, Environment>;
     _state = state;
     _dispatch = store.dispatch;
     _getAndRemoveFirstError = store.getAndRemoveFirstError;
@@ -178,7 +178,7 @@ abstract class VmFactory<St, T> {
   St currentState() => _store.state;
 
   /// Dispatch an action, possibly changing the store state.
-  Dispatch<St> get dispatch => _dispatch;
+  Dispatch<St, Environment> get dispatch => _dispatch;
 
   UserException? getAndRemoveFirstError() => _getAndRemoveFirstError();
 }
@@ -193,7 +193,7 @@ void internalsVmFactoryInject<St>(VmFactory vmFactory, St state, Store store) {
 /// Don't use, this is deprecated. Please, use the recommended [Vm] class.
 /// This should only be used for IMMUTABLE classes.
 /// Lets you implement equals/hashcode without having to override these methods.
-abstract class BaseModel<St> {
+abstract class BaseModel<St, Environment> {
   /// The List of properties which will be used to determine whether two BaseModels are equal.
   final List<Object?> equals;
 
@@ -242,14 +242,14 @@ abstract class BaseModel<St> {
   }
 
   late St _state;
-  Dispatch<St>? _dispatch;
+  Dispatch<St, Environment>? _dispatch;
   UserException? Function()? _getAndRemoveFirstError;
 
   BaseModel fromStore();
 
   St get state => _state;
 
-  Dispatch<St>? get dispatch => _dispatch;
+  Dispatch<St, Environment>? get dispatch => _dispatch;
 
   UserException? Function()? get getAndRemoveFirstError => //
       _getAndRemoveFirstError;

--- a/lib/src/wait_action.dart
+++ b/lib/src/wait_action.dart
@@ -124,7 +124,7 @@ class WaitAction<St, Environment> extends ReduxAction<St, Environment> {
         ref = null;
 
   @override
-  St? reduce({required Environment environment}) => reducer(state, operation, flag, ref);
+  St? reduce() => reducer(state, operation, flag, ref);
 }
 
 typedef WaitReducer<St> = St? Function(

--- a/lib/src/wait_action.dart
+++ b/lib/src/wait_action.dart
@@ -38,7 +38,7 @@ import '../async_redux.dart';
 /// 5) Don't use the [WaitAction], but instead create your own `MyWaitAction`
 /// that uses the [Wait] object in whatever way you want.
 ///
-class WaitAction<St> extends ReduxAction<St> {
+class WaitAction<St, Environment> extends ReduxAction<St, Environment> {
   //
 
   /// Works out-of-the-box for most use cases, but you can inject your
@@ -124,7 +124,7 @@ class WaitAction<St> extends ReduxAction<St> {
         ref = null;
 
   @override
-  St? reduce() => reducer(state, operation, flag, ref);
+  St? reduce({required Environment environment}) => reducer(state, operation, flag, ref);
 }
 
 typedef WaitReducer<St> = St? Function(

--- a/lib/src/wrap_error.dart
+++ b/lib/src/wrap_error.dart
@@ -36,10 +36,10 @@ import 'package:async_redux/async_redux.dart';
 ///     }}
 ///   return null; }
 /// ```
-abstract class WrapError<St> {
+abstract class WrapError<St, Environment> {
   Object? wrap(
     Object error,
     StackTrace stackTrace,
-    ReduxAction<St> action,
+    ReduxAction<St, Environment> action,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: ^1.16.8
+  test:
   flutter_test:
     sdk: flutter
 

--- a/test/abort_dispatch_test.dart
+++ b/test/abort_dispatch_test.dart
@@ -14,7 +14,7 @@ void main() {
   test('Test aborting an action.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     store.dispatch(ActionA(abort: false));
     expect(store.state, "X");
@@ -35,7 +35,7 @@ void main() {
   test('Test aborting an action, where the abortDispatch method accesses the state.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     store.dispatch(ActionB());
     expect(store.state, "X");
@@ -56,7 +56,7 @@ void main() {
 
 // ----------------------------------------------
 
-class ActionA extends ReduxAction<String> {
+class ActionA extends ReduxAction<String, int> {
   bool abort;
 
   ActionA({required this.abort});
@@ -70,7 +70,7 @@ class ActionA extends ReduxAction<String> {
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info!.add('2');
     return state + 'X';
   }
@@ -83,7 +83,7 @@ class ActionA extends ReduxAction<String> {
 
 // ----------------------------------------------
 
-class ActionB extends ReduxAction<String> {
+class ActionB extends ReduxAction<String, int> {
   @override
   bool abortDispatch() => state.length >= 2;
 
@@ -93,7 +93,7 @@ class ActionB extends ReduxAction<String> {
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info!.add('2');
     return state + 'X';
   }

--- a/test/abort_dispatch_test.dart
+++ b/test/abort_dispatch_test.dart
@@ -70,7 +70,7 @@ class ActionA extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info!.add('2');
     return state + 'X';
   }
@@ -93,7 +93,7 @@ class ActionB extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info!.add('2');
     return state + 'X';
   }

--- a/test/action_status_test.dart
+++ b/test/action_status_test.dart
@@ -105,7 +105,7 @@ class MyAction extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info.add('2');
     if (whenToThrow == When.reduce) throw const UserException("During reduce");
     return state + 'X';

--- a/test/action_status_test.dart
+++ b/test/action_status_test.dart
@@ -21,7 +21,7 @@ void main() {
   test('Test detecting that the BEFORE method of an action threw an error.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     var actionA = MyAction(whenToThrow: When.before);
     store.dispatch(actionA);
@@ -36,7 +36,7 @@ void main() {
   test('Test detecting that the REDUCE method of an action threw an error.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     var actionA = MyAction(whenToThrow: When.reduce);
     store.dispatch(actionA);
@@ -54,7 +54,7 @@ void main() {
       "thrown asynchronously (after the async gap).", () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     var hasThrown = false;
     runZonedGuarded(() {
@@ -78,7 +78,7 @@ void main() {
   test('Test detecting that the action threw no errors.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     var actionA = MyAction(whenToThrow: null);
     store.dispatch(actionA);
@@ -93,7 +93,7 @@ void main() {
 
 // ----------------------------------------------
 
-class MyAction extends ReduxAction<String> {
+class MyAction extends ReduxAction<String, int> {
   When? whenToThrow;
 
   MyAction({this.whenToThrow});
@@ -105,7 +105,7 @@ class MyAction extends ReduxAction<String> {
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info.add('2');
     if (whenToThrow == When.reduce) throw const UserException("During reduce");
     return state + 'X';

--- a/test/after_throws_test.dart
+++ b/test/after_throws_test.dart
@@ -59,7 +59,7 @@ class ActionA extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info.add('A.reduce state="$state"');
     return state + 'A';
   }

--- a/test/after_throws_test.dart
+++ b/test/after_throws_test.dart
@@ -20,11 +20,11 @@ void main() {
     //
     dynamic error;
     dynamic asyncError;
-    late Store<String> store;
+    late Store<String, int> store;
 
     await runZonedGuarded(() async {
       info = [];
-      store = Store<String>(initialState: "");
+      store = Store<String, int>(initialState: "", environment: 0);
 
       try {
         store.dispatch(ActionA());
@@ -52,14 +52,14 @@ void main() {
   /////////////////////////////////////////////////////////////////////////////
 }
 
-class ActionA extends ReduxAction<String> {
+class ActionA extends ReduxAction<String, int> {
   @override
   void before() {
     info.add('A.before state="$state"');
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info.add('A.reduce state="$state"');
     return state + 'A';
   }

--- a/test/before_reduce_after_order_test.dart
+++ b/test/before_reduce_after_order_test.dart
@@ -16,7 +16,7 @@ void main() {
   test('Method call sequence for sync reducer.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
     store.dispatch(ActionA());
     expect(store.state, "A");
     expect(info, [
@@ -33,7 +33,7 @@ void main() {
       'The reducer is async because the method returns Future.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
     await store.dispatch(ActionB());
     expect(store.state, "B");
     expect(info, [
@@ -51,7 +51,7 @@ void main() {
       'The reducer is async because the REDUCE method returns Future.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     // B is dispatched first, but will finish last, because it's async.
     var f1 = store.dispatch(ActionB());
@@ -77,7 +77,7 @@ void main() {
       'The reducer is async because the BEFORE method returns Future.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     // C is dispatched first, but will finish last, because it's async.
     var f1 = store.dispatch(ActionC());
@@ -103,7 +103,7 @@ void main() {
       'Shows what happens if the before method actually awaits.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
 
     // D is dispatched first, but will finish last, because it's async.
     var f1 = store.dispatch(ActionD());
@@ -129,7 +129,7 @@ void main() {
       'The state is changed by the reduce method before the after method is executed.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
     await store.dispatch(ActionE());
 
     //
@@ -152,7 +152,7 @@ void main() {
       'The state is changed by the reduce method before the after method is executed.', () async {
     //
     info = [];
-    Store<String> store = Store<String>(initialState: "");
+    Store<String, int> store = Store<String, int>(initialState: "", environment: 0);
     await store.dispatch(ActionF());
 
     //
@@ -176,14 +176,14 @@ void main() {
 
 // ----------------------------------------------
 
-class ActionA extends ReduxAction<String> {
+class ActionA extends ReduxAction<String, int> {
   @override
   void before() {
     info.add('A.before state="$state"');
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info.add('A.reduce state="$state"');
     return state + 'A';
   }
@@ -196,14 +196,14 @@ class ActionA extends ReduxAction<String> {
 
 // ----------------------------------------------
 
-class ActionB extends ReduxAction<String> {
+class ActionB extends ReduxAction<String, int> {
   @override
   void before() {
     info.add('B.before state="$state"');
   }
 
   @override
-  Future<String> reduce() async {
+  Future<String> reduce({required int environment}) async {
     info.add('B.reduce1 state="$state"');
     await Future.delayed(const Duration(milliseconds: 50));
     info.add('B.reduce2 state="$state"');
@@ -218,14 +218,14 @@ class ActionB extends ReduxAction<String> {
 
 // ----------------------------------------------
 
-class ActionC extends ReduxAction<String> {
+class ActionC extends ReduxAction<String, int> {
   @override
   Future<void> before() async {
     info.add('C.before state="$state"');
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info.add('C.reduce state="$state"');
     return state + 'C';
   }
@@ -238,7 +238,7 @@ class ActionC extends ReduxAction<String> {
 
 // ----------------------------------------------
 
-class ActionD extends ReduxAction<String> {
+class ActionD extends ReduxAction<String, int> {
   @override
   Future<void> before() async {
     info.add('D.before1 state="$state"');
@@ -247,7 +247,7 @@ class ActionD extends ReduxAction<String> {
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info.add('D.reduce state="$state"');
     return state + 'D';
   }
@@ -260,14 +260,14 @@ class ActionD extends ReduxAction<String> {
 
 // ----------------------------------------------
 
-class ActionE extends ReduxAction<String> {
+class ActionE extends ReduxAction<String, int> {
   @override
   void before() async {
     info.add('E.before state="$state"');
   }
 
   @override
-  String reduce() {
+  String reduce({required int environment}) {
     info.add('E.reduce state="$state"');
     return state + 'E';
   }
@@ -282,14 +282,14 @@ class ActionE extends ReduxAction<String> {
 
 // ----------------------------------------------
 
-class ActionF extends ReduxAction<String> {
+class ActionF extends ReduxAction<String, int> {
   @override
   void before() async {
     info.add('F.before state="$state"');
   }
 
   @override
-  Future<String> reduce() async {
+  Future<String> reduce({required int environment}) async {
     info.add('F.reduce1 state="$state"');
     await Future.delayed(const Duration(milliseconds: 10));
     info.add('F.reduce2 state="$state"');

--- a/test/before_reduce_after_order_test.dart
+++ b/test/before_reduce_after_order_test.dart
@@ -183,7 +183,7 @@ class ActionA extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info.add('A.reduce state="$state"');
     return state + 'A';
   }
@@ -203,7 +203,7 @@ class ActionB extends ReduxAction<String, int> {
   }
 
   @override
-  Future<String> reduce({required int environment}) async {
+  Future<String> reduce() async {
     info.add('B.reduce1 state="$state"');
     await Future.delayed(const Duration(milliseconds: 50));
     info.add('B.reduce2 state="$state"');
@@ -225,7 +225,7 @@ class ActionC extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info.add('C.reduce state="$state"');
     return state + 'C';
   }
@@ -247,7 +247,7 @@ class ActionD extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info.add('D.reduce state="$state"');
     return state + 'D';
   }
@@ -267,7 +267,7 @@ class ActionE extends ReduxAction<String, int> {
   }
 
   @override
-  String reduce({required int environment}) {
+  String reduce() {
     info.add('E.reduce state="$state"');
     return state + 'E';
   }
@@ -289,7 +289,7 @@ class ActionF extends ReduxAction<String, int> {
   }
 
   @override
-  Future<String> reduce({required int environment}) async {
+  Future<String> reduce() async {
     info.add('F.reduce1 state="$state"');
     await Future.delayed(const Duration(milliseconds: 10));
     info.add('F.reduce2 state="$state"');

--- a/test/mock_store_test.dart
+++ b/test/mock_store_test.dart
@@ -17,7 +17,7 @@ class MyAction extends ReduxAction<AppState, AppEnvironment> {
   MyAction(this.value);
 
   @override
-  AppState reduce({required AppEnvironment environment}) => AppState(state.text + value.toString());
+  AppState reduce() => AppState(state.text + value.toString());
 }
 
 class MyAction1 extends MyAction {
@@ -42,7 +42,7 @@ class MyAction5 extends MyAction {
 
 class MyMockAction extends MockAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => AppState(state.text + '[' + (action as MyAction).value.toString() + ']');
+  AppState reduce() => AppState(state.text + '[' + (action as MyAction).value.toString() + ']');
 }
 
 void main() {

--- a/test/model_observer_test.dart
+++ b/test/model_observer_test.dart
@@ -13,12 +13,13 @@ void main() {
     (WidgetTester tester) async {
       //
       var modelObserver = DefaultModelObserver<_MyViewModel>();
-      Store<_StateTest> store = Store<_StateTest>(
+      Store<_StateTest, _EnvironmentTest> store = Store<_StateTest, _EnvironmentTest>(
         initialState: _StateTest("A", 1),
+        environment: _EnvironmentTest(),
         modelObserver: modelObserver,
       );
 
-      StoreProvider<_StateTest> provider = StoreProvider<_StateTest>(
+      StoreProvider<_StateTest, _EnvironmentTest> provider = StoreProvider<_StateTest, _EnvironmentTest>(
         store: store,
         child: const _MyWidgetConnector(),
       );
@@ -77,7 +78,7 @@ void main() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class _TestApp extends StatelessWidget {
-  final StoreProvider<_StateTest> provider;
+  final StoreProvider<_StateTest, _EnvironmentTest> provider;
 
   _TestApp(this.provider);
 
@@ -95,20 +96,25 @@ class _StateTest {
   _StateTest(this.text, this.number);
 }
 
+@immutable
+class _EnvironmentTest {
+
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class _MyWidgetConnector extends StatelessWidget {
   const _MyWidgetConnector();
 
   @override
-  Widget build(BuildContext context) => StoreConnector<_StateTest, _MyViewModel>(
+  Widget build(BuildContext context) => StoreConnector<_StateTest, _EnvironmentTest, _MyViewModel>(
         debug: this,
         model: _MyViewModel(),
         builder: (BuildContext context, _MyViewModel vm) => Container(),
       );
 }
 
-class _MyViewModel extends BaseModel<_StateTest> {
+class _MyViewModel extends BaseModel<_StateTest, _EnvironmentTest> {
   _MyViewModel();
 
   String? text;
@@ -121,14 +127,14 @@ class _MyViewModel extends BaseModel<_StateTest> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-class _MyAction extends ReduxAction<_StateTest> {
+class _MyAction extends ReduxAction<_StateTest, _EnvironmentTest> {
   String text;
   int number;
 
   _MyAction(this.text, this.number);
 
   @override
-  _StateTest reduce() => _StateTest(text, number);
+  _StateTest reduce({required _EnvironmentTest environment}) => _StateTest(text, number);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/model_observer_test.dart
+++ b/test/model_observer_test.dart
@@ -134,7 +134,7 @@ class _MyAction extends ReduxAction<_StateTest, _EnvironmentTest> {
   _MyAction(this.text, this.number);
 
   @override
-  _StateTest reduce({required _EnvironmentTest environment}) => _StateTest(text, number);
+  _StateTest reduce() => _StateTest(text, number);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/navigate_action_test.dart
+++ b/test/navigate_action_test.dart
@@ -3,7 +3,7 @@ import 'package:async_redux/src/store_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-late Store<AppState> store;
+late Store<AppState, AppEnvironment> store;
 
 final navigatorKey = GlobalKey<NavigatorState>();
 
@@ -15,10 +15,12 @@ final routes = {
 
 class AppState {}
 
+class AppEnvironment {}
+
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return StoreProvider<AppState>(
+    return StoreProvider<AppState, AppEnvironment>(
       store: store,
       child: MaterialApp(
         initialRoute: "/",
@@ -82,7 +84,10 @@ class MyPage extends StatelessWidget {
 void main() {
   setUp(() async {
     NavigateAction.setNavigatorKey(navigatorKey);
-    store = Store<AppState>(initialState: AppState());
+    store = Store<AppState, AppEnvironment>(
+      initialState: AppState(),
+      environment: AppEnvironment()
+    );
   });
 
   final Finder page1Finder = find.byKey(const Key("page1"));

--- a/test/persistence_test.dart
+++ b/test/persistence_test.dart
@@ -757,7 +757,7 @@ class ChangeNameAction extends ReduxAction<AppState, AppEnvironment> {
   ChangeNameAction(this.name);
 
   @override
-  AppState reduce({required AppEnvironment environment}) => state.copy(name: name);
+  AppState reduce() => state.copy(name: name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/store_observer_test.dart
+++ b/test/store_observer_test.dart
@@ -9,7 +9,7 @@ class _MyAction extends ReduxAction<num, int> {
   _MyAction(this.number);
 
   @override
-  num reduce({required int environment}) => number;
+  num reduce() => number;
 }
 
 class _MyAsyncAction extends ReduxAction<num, int> {
@@ -18,7 +18,7 @@ class _MyAsyncAction extends ReduxAction<num, int> {
   _MyAsyncAction(this.number);
 
   @override
-  Future<num> reduce({required int environment}) async {
+  Future<num> reduce() async {
     await Future.sync(() {});
     return number;
   }

--- a/test/store_observer_test.dart
+++ b/test/store_observer_test.dart
@@ -3,33 +3,33 @@ import 'dart:async';
 import 'package:async_redux/async_redux.dart';
 import "package:test/test.dart";
 
-class _MyAction extends ReduxAction<num> {
+class _MyAction extends ReduxAction<num, int> {
   final num number;
 
   _MyAction(this.number);
 
   @override
-  num reduce() => number;
+  num reduce({required int environment}) => number;
 }
 
-class _MyAsyncAction extends ReduxAction<num> {
+class _MyAsyncAction extends ReduxAction<num, int> {
   final num number;
 
   _MyAsyncAction(this.number);
 
   @override
-  Future<num> reduce() async {
+  Future<num> reduce({required int environment}) async {
     await Future.sync(() {});
     return number;
   }
 }
 
-class _MyStateObserver extends StateObserver<num?> {
+class _MyStateObserver extends StateObserver<num?, int> {
   num? iniValue;
   num? endValue;
 
   @override
-  void observe(ReduxAction<num?> action, num? stateIni, num? stateEnd, int dispatchCount) {
+  void observe(ReduxAction<num?, int> action, num? stateIni, num? stateEnd, int dispatchCount) {
     iniValue = stateIni;
     endValue = stateEnd;
   }
@@ -37,8 +37,12 @@ class _MyStateObserver extends StateObserver<num?> {
 
 void main() {
   var observer = _MyStateObserver();
-  StoreTester<num> createStoreTester() {
-    var store = Store<num>(initialState: 0, stateObservers: [observer]);
+  StoreTester<num, int> createStoreTester() {
+    var store = Store<num, int>(
+      initialState: 0, 
+      environment: 0,
+      stateObservers: [observer]
+    );
     return StoreTester.from(store);
   }
 
@@ -49,7 +53,7 @@ void main() {
     expect(storeTester.state, 0);
 
     storeTester.dispatch(_MyAction(1));
-    var condition = (TestInfo<num?>? info) => info!.state == 1;
+    var condition = (TestInfo<num?, int>? info) => info!.state == 1;
     await storeTester.waitConditionGetLast(condition);
     expect(observer.iniValue, 0);
     expect(observer.endValue, 1);
@@ -62,7 +66,7 @@ void main() {
     expect(storeTester.state, 0);
 
     storeTester.dispatch(_MyAsyncAction(1));
-    var condition = (TestInfo<num?>? info) => info!.state == 1;
+    var condition = (TestInfo<num?, int>? info) => info!.state == 1;
     await storeTester.waitConditionGetLast(condition);
     expect(observer.iniValue, 0);
     expect(observer.endValue, 1);

--- a/test/store_tester_test.dart
+++ b/test/store_tester_test.dart
@@ -11,42 +11,44 @@ class AppState {
   AppState.add(AppState state, String text) : text = state.text + "," + text;
 }
 
-class Action1 extends ReduxAction<AppState> {
+class AppEnvironment {}
+
+class Action1 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() => AppState.add(state, "1");
+  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "1");
 }
 
-class Action2 extends ReduxAction<AppState> {
+class Action2 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() => AppState.add(state, "2");
+  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "2");
 }
 
-class Action3 extends ReduxAction<AppState> {
+class Action3 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() => AppState.add(state, "3");
+  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "3");
 }
 
-class Action3b extends ReduxAction<AppState> {
+class Action3b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     dispatch(Action4());
     return AppState.add(state, "3b");
   }
 }
 
-class Action4 extends ReduxAction<AppState> {
+class Action4 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() => AppState.add(state, "4");
+  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "4");
 }
 
-class Action5 extends ReduxAction<AppState> {
+class Action5 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() => AppState.add(state, "5");
+  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "5");
 }
 
-class Action6 extends ReduxAction<AppState> {
+class Action6 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action3());
@@ -54,9 +56,9 @@ class Action6 extends ReduxAction<AppState> {
   }
 }
 
-class Action6b extends ReduxAction<AppState> {
+class Action6b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     dispatch(Action1());
     await Future.delayed(const Duration(milliseconds: 10));
     dispatch(Action2());
@@ -65,9 +67,9 @@ class Action6b extends ReduxAction<AppState> {
   }
 }
 
-class Action6c extends ReduxAction<AppState> {
+class Action6c extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action3b());
@@ -75,9 +77,9 @@ class Action6c extends ReduxAction<AppState> {
   }
 }
 
-class Action7 extends ReduxAction<AppState> {
+class Action7 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     dispatch(Action4());
     dispatch(Action6());
     dispatch(Action2());
@@ -86,9 +88,9 @@ class Action7 extends ReduxAction<AppState> {
   }
 }
 
-class Action7b extends ReduxAction<AppState> {
+class Action7b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     dispatch(Action4());
     dispatch(Action6b());
     dispatch(Action2());
@@ -97,26 +99,26 @@ class Action7b extends ReduxAction<AppState> {
   }
 }
 
-class Action8 extends ReduxAction<AppState> {
+class Action8 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.delayed(const Duration(milliseconds: 50));
     dispatch(Action2());
     return AppState.add(state, "8");
   }
 }
 
-class Action9 extends ReduxAction<AppState> {
+class Action9 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.delayed(const Duration(milliseconds: 100));
     return AppState.add(state, "9");
   }
 }
 
-class Action10a extends ReduxAction<AppState> {
+class Action10a extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action11a());
@@ -125,9 +127,9 @@ class Action10a extends ReduxAction<AppState> {
   }
 }
 
-class Action10b extends ReduxAction<AppState> {
+class Action10b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action11b());
@@ -136,39 +138,39 @@ class Action10b extends ReduxAction<AppState> {
   }
 }
 
-class Action11a extends ReduxAction<AppState> {
+class Action11a extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     throw const UserException("Hello!");
   }
 }
 
-class Action11b extends ReduxAction<AppState> {
+class Action11b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     throw const UserException("Hello!");
   }
 }
 
-class Action12 extends ReduxAction<AppState> {
+class Action12 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     dispatch(Action13());
     return AppState.add(state, "12");
   }
 }
 
-class Action13 extends ReduxAction<AppState> {
+class Action13 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.delayed(const Duration(milliseconds: 1));
     return AppState.add(state, "13");
   }
 }
 
 void main() {
-  StoreTester<AppState> createStoreTester() {
-    var store = Store<AppState>(initialState: AppState("0"));
+  StoreTester<AppState, AppEnvironment> createStoreTester() {
+    var store = Store<AppState, AppEnvironment>(initialState: AppState("0"), environment: AppEnvironment());
     return StoreTester.from(store);
   }
 
@@ -223,12 +225,12 @@ void main() {
     storeTester.dispatch(Action3());
     storeTester.dispatch(Action4());
 
-    var condition = (TestInfo<AppState?>? info) => info!.state!.text == "0,1,2";
-    TestInfo<AppState?> info1 = await (storeTester.waitConditionGetLast(condition));
+    var condition = (TestInfo<AppState?, AppEnvironment>? info) => info!.state!.text == "0,1,2";
+    TestInfo<AppState?, AppEnvironment> info1 = await (storeTester.waitConditionGetLast(condition));
     expect(info1.state!.text, "0,1,2");
     expect(info1.ini, false);
 
-    TestInfo<AppState?> info2 =
+    TestInfo<AppState?, AppEnvironment> info2 =
         await (storeTester.waitConditionGetLast((info) => info.state.text == "0,1,2,3,4"));
     expect(info2.state!.text, "0,1,2,3,4");
     expect(info2.ini, false);
@@ -247,13 +249,13 @@ void main() {
     storeTester.dispatch(Action3());
     storeTester.dispatch(Action4());
 
-    var condition = (TestInfo<AppState?>? info) => info!.state!.text == "0,1,2" && info.ini;
-    TestInfo<AppState?> info1 =
+    var condition = (TestInfo<AppState?, AppEnvironment>? info) => info!.state!.text == "0,1,2" && info.ini;
+    TestInfo<AppState?, AppEnvironment> info1 =
         await (storeTester.waitConditionGetLast(condition, ignoreIni: false));
     expect(info1.state!.text, "0,1,2");
     expect(info1.ini, true);
 
-    TestInfo<AppState?> info2 = await (storeTester.waitConditionGetLast(
+    TestInfo<AppState?, AppEnvironment> info2 = await (storeTester.waitConditionGetLast(
         (info) => info.state.text == "0,1,2,3,4" && !info.ini,
         ignoreIni: false));
     expect(info2.state!.text, "0,1,2,3,4");
@@ -273,7 +275,7 @@ void main() {
     storeTester.dispatch(Action3());
     storeTester.dispatch(Action4());
 
-    TestInfoList<AppState?> infos =
+    TestInfoList<AppState?, AppEnvironment> infos =
         await storeTester.waitCondition((info) => info.state.text == "0,1,2");
 
     expect(infos.length, 2);
@@ -304,7 +306,7 @@ void main() {
     storeTester.dispatch(Action3());
     storeTester.dispatch(Action4());
 
-    TestInfoList<AppState?> infos =
+    TestInfoList<AppState?, AppEnvironment> infos =
         await storeTester.waitCondition((info) => info.state.text == "0,1,2", ignoreIni: false);
     expect(infos.length, 4);
     expect(infos.getIndex(0).state!.text, "0");
@@ -338,7 +340,7 @@ void main() {
     expect(storeTester.state.text, "0");
 
     storeTester.dispatch(Action1());
-    TestInfo<AppState?> info = await (storeTester.wait(Action1));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.wait(Action1));
     expect(info.state!.text, "0,1");
     expect(info.errors, isEmpty);
   });
@@ -384,7 +386,7 @@ void main() {
     storeTester.dispatch(Action1());
     storeTester.dispatch(Action2());
     storeTester.dispatch(Action3());
-    TestInfo<AppState?> info = await (storeTester.waitAllGetLast([Action1, Action2, Action3]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllGetLast([Action1, Action2, Action3]));
     expect(info.state!.text, "0,1,2,3");
     expect(info.errors, isEmpty);
   });
@@ -400,7 +402,7 @@ void main() {
     // Action6 will dispatch actions 1, 2 and 3, and only then it will finish.
     storeTester.dispatch(Action6());
 
-    TestInfo<AppState?> info =
+    TestInfo<AppState?, AppEnvironment> info =
         await (storeTester.waitAllGetLast([Action6, Action1, Action2, Action3]));
     expect(info.state!.text, "0,1,2,3,6");
     expect(info.errors, isEmpty);
@@ -471,7 +473,7 @@ void main() {
     storeTester.dispatch(Action3());
     storeTester.dispatch(Action4());
 
-    TestInfo<AppState?> info = await storeTester.waitUntil(Action3);
+    TestInfo<AppState?, AppEnvironment> info = await storeTester.waitUntil(Action3);
     expect(info.state!.text, "0,1,2,3");
     expect(info.errors, isEmpty);
   });
@@ -512,7 +514,7 @@ void main() {
     storeTester.dispatch(action3);
     storeTester.dispatch(Action4());
 
-    TestInfo<AppState?> info = await storeTester.waitUntilAction(action3);
+    TestInfo<AppState?, AppEnvironment> info = await storeTester.waitUntilAction(action3);
     expect(info.state!.text, "0,1,2,3");
     expect(info.errors, isEmpty);
   });
@@ -549,7 +551,7 @@ void main() {
     storeTester.dispatch(Action1());
     storeTester.dispatch(Action2());
     storeTester.dispatch(Action3());
-    TestInfo<AppState?> info =
+    TestInfo<AppState?, AppEnvironment> info =
         await (storeTester.waitAllUnorderedGetLast([Action3, Action1, Action2]));
     expect(info.state!.text, "0,1,2,3");
     expect(info.errors, isEmpty);
@@ -587,7 +589,7 @@ void main() {
     storeTester.dispatch(Action1());
     storeTester.dispatch(Action2());
     storeTester.dispatch(Action3());
-    TestInfoList<AppState?> infos = await storeTester.waitAll([Action1, Action2, Action3]);
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll([Action1, Action2, Action3]);
     expect(infos.getIndex(0).state!.text, "0,1");
     expect(infos.getIndex(1).state!.text, "0,1,2");
     expect(infos.getIndex(2).state!.text, "0,1,2,3");
@@ -608,7 +610,7 @@ void main() {
     storeTester.dispatch(Action2());
     storeTester.dispatch(Action2());
     storeTester.dispatch(Action3());
-    TestInfoList<AppState?> infos = await storeTester
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester
         .waitAllUnordered([Action1, Action2, Action3, Action2], timeoutInSeconds: 1);
 
     // The states are indexed by order of dispatching
@@ -653,7 +655,7 @@ void main() {
     expect(infos.get(Action3, 500), isNull);
 
     // Get repeated actions as list.
-    List<TestInfo<AppState?>?> action2s = infos.getAll(Action2);
+    List<TestInfo<AppState?, AppEnvironment>?> action2s = infos.getAll(Action2);
     expect(action2s.length, 2);
     expect(action2s[0]!.state!.text, "0,1,2");
     expect(action2s[1]!.state!.text, "0,1,2,2");
@@ -672,7 +674,7 @@ void main() {
     storeTester.dispatch(Action2());
     storeTester.dispatch(Action2());
     storeTester.dispatch(Action3());
-    TestInfoList<AppState?> infos = await storeTester.waitAllUnordered(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAllUnordered(
       [Action1, Action3],
       timeoutInSeconds: 1,
       ignore: [Action2],
@@ -707,7 +709,7 @@ void main() {
     storeTester.dispatch(Action5());
     storeTester.dispatch(Action4());
 
-    TestInfo<AppState?> info = await (storeTester.waitAllGetLast(
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllGetLast(
       [Action1, Action3, Action5],
       ignore: [Action2, Action4],
     ));
@@ -738,7 +740,7 @@ void main() {
     storeTester.dispatch(Action5());
     storeTester.dispatch(Action4());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [Action1, Action3, Action5],
       ignore: [Action2, Action4],
     );
@@ -771,7 +773,7 @@ void main() {
 
     storeTester.dispatch(Action3());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [Action1, Action2, Action3],
       ignore: [Action2],
     );
@@ -811,7 +813,7 @@ void main() {
     storeTester.dispatch(Action5());
     storeTester.dispatch(Action4());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [Action1, Action3, Action4, Action5],
       ignore: [Action2, Action4],
     );
@@ -842,7 +844,7 @@ void main() {
     // Action6 will dispatch actions 1, 2 and 3, and only then it will finish.
     storeTester.dispatch(Action6());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [Action6, Action1, Action2, Action3],
       ignore: [Action6],
     );
@@ -871,7 +873,7 @@ void main() {
     // Action6 will dispatch actions 1, 2 and 3, and only then it will finish.
     storeTester.dispatch(Action7());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [Action7, Action4, Action6, Action1, Action2, Action3, Action5],
       ignore: [Action2],
     );
@@ -904,7 +906,7 @@ void main() {
     // Action6b will dispatch actions 1, 2 and 3, and only then it will finish.
     storeTester.dispatch(Action7b());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [Action7b, Action4, Action6b, Action2, Action5, Action1, Action2, Action3],
     );
 
@@ -930,7 +932,7 @@ void main() {
     // Action6b will dispatch actions 1, 2 and 3, and only then it will finish.
     storeTester.dispatch(Action7b());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [Action7b, Action4, Action6b, Action2, Action5, Action1, Action3],
       ignore: [Action2],
     );
@@ -958,7 +960,7 @@ void main() {
 
     storeTester.dispatch(Action9());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [
         Action9,
         Action2,
@@ -990,7 +992,7 @@ void main() {
     storeTester.dispatch(Action9());
     storeTester.dispatch(Action1());
 
-    TestInfoList<AppState?> infos = await storeTester.waitAll(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitAll(
       [
         Action9,
         Action9,
@@ -1045,7 +1047,7 @@ void main() {
     var storeTester = createStoreTester();
     expect(storeTester.state.text, "0");
     storeTester.dispatch(Action6());
-    TestInfo<AppState?> info = await (storeTester.waitAllGetLast(
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllGetLast(
       [
         Action1,
         Action2,
@@ -1074,7 +1076,7 @@ void main() {
     var storeTester = createStoreTester();
     expect(storeTester.state.text, "0");
     storeTester.dispatch(Action6());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast(
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast(
       [
         Action1,
         Action2,
@@ -1102,7 +1104,7 @@ void main() {
     var storeTester = createStoreTester();
     expect(storeTester.state.text, "0");
     storeTester.dispatch(Action6());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast(
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast(
       [
         Action1,
         Action2,
@@ -1162,7 +1164,7 @@ void main() {
       expect(error, const UserException("Hello!"));
     });
 
-    TestInfo<AppState?> info = await storeTester.waitUntil(Action11a);
+    TestInfo<AppState?, AppEnvironment> info = await storeTester.waitUntil(Action11a);
     expect(info.error, const UserException("Hello!"));
     expect(info.processedError, null);
     expect(info.state!.text, "0,1,2");
@@ -1183,7 +1185,7 @@ void main() {
       expect(error, const UserException("Hello!"));
     });
 
-    TestInfo<AppState?> info = await storeTester.waitUntil(Action11b);
+    TestInfo<AppState?, AppEnvironment> info = await storeTester.waitUntil(Action11b);
     expect(info.error, const UserException("Hello!"));
     expect(info.processedError, null);
     expect(info.state!.text, "0,1,2,3,10");
@@ -1203,7 +1205,7 @@ void main() {
       storeTester.dispatch(Action10a());
     }, (error, stackTrace) {});
 
-    TestInfo<AppState?> info = await (storeTester.waitUntilErrorGetLast(
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitUntilErrorGetLast(
       error: UserException,
       timeoutInSeconds: 1,
     ));
@@ -1227,7 +1229,7 @@ void main() {
       storeTester.dispatch(Action10a());
     }, (error, stackTrace) {});
 
-    TestInfo<AppState?> info = await (storeTester.waitUntilErrorGetLast(
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitUntilErrorGetLast(
       error: const UserException("Hello!"),
       timeoutInSeconds: 1,
     ));
@@ -1249,7 +1251,7 @@ void main() {
     storeTester.dispatch(Action3());
     storeTester.dispatch(Action4());
 
-    var condition = (TestInfo<AppState?>? info) => info!.state!.text == "0,1,2";
+    var condition = (TestInfo<AppState?, AppEnvironment>? info) => info!.state!.text == "0,1,2";
     await storeTester.waitConditionGetLast(condition);
 
     // Same as expect(info1.state.text, "0,1,2");
@@ -1305,7 +1307,7 @@ void main() {
     storeTester.dispatch(Action3());
     storeTester.dispatch(Action4());
 
-    TestInfo<AppState?> info = await (storeTester
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester
         .waitConditionGetLast((info) => info.state.text == "0", timeoutInSeconds: 1));
 
     expect(info.state!.text, "0");
@@ -1342,7 +1344,7 @@ void main() {
 
     storeTester.dispatch(Action1());
 
-    TestInfoList<AppState?> infos = await storeTester.waitCondition(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitCondition(
       (info) => info.state.text == "0,1",
       testImmediately: true,
     );
@@ -1369,7 +1371,7 @@ void main() {
 
     storeTester.dispatch(Action1());
 
-    TestInfoList<AppState?> infos = await storeTester.waitCondition(
+    TestInfoList<AppState?, AppEnvironment> infos = await storeTester.waitCondition(
       (info) => info.state.text == "0,1",
       testImmediately: true,
     );
@@ -1411,10 +1413,10 @@ void main() {
     storeTester1.dispatch(Action3());
     storeTester1.dispatch(Action4());
 
-    TestInfo<AppState?> info1 = await (storeTester1
+    TestInfo<AppState?, AppEnvironment> info1 = await (storeTester1
         .waitConditionGetLast((info) => info.state.text == "0,1,2,3", timeoutInSeconds: 1));
 
-    TestInfo<AppState?> info2 = await (storeTester2
+    TestInfo<AppState?, AppEnvironment> info2 = await (storeTester2
         .waitConditionGetLast((info) => info.state.text == "0,1", timeoutInSeconds: 1));
 
     expect(info1.state!.text, "0,1,2,3");

--- a/test/store_tester_test.dart
+++ b/test/store_tester_test.dart
@@ -15,22 +15,22 @@ class AppEnvironment {}
 
 class Action1 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "1");
+  AppState reduce() => AppState.add(state, "1");
 }
 
 class Action2 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "2");
+  AppState reduce() => AppState.add(state, "2");
 }
 
 class Action3 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "3");
+  AppState reduce() => AppState.add(state, "3");
 }
 
 class Action3b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     dispatch(Action4());
     return AppState.add(state, "3b");
   }
@@ -38,17 +38,17 @@ class Action3b extends ReduxAction<AppState, AppEnvironment> {
 
 class Action4 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "4");
+  AppState reduce() => AppState.add(state, "4");
 }
 
 class Action5 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) => AppState.add(state, "5");
+  AppState reduce() => AppState.add(state, "5");
 }
 
 class Action6 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action3());
@@ -58,7 +58,7 @@ class Action6 extends ReduxAction<AppState, AppEnvironment> {
 
 class Action6b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     dispatch(Action1());
     await Future.delayed(const Duration(milliseconds: 10));
     dispatch(Action2());
@@ -69,7 +69,7 @@ class Action6b extends ReduxAction<AppState, AppEnvironment> {
 
 class Action6c extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action3b());
@@ -79,7 +79,7 @@ class Action6c extends ReduxAction<AppState, AppEnvironment> {
 
 class Action7 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     dispatch(Action4());
     dispatch(Action6());
     dispatch(Action2());
@@ -90,7 +90,7 @@ class Action7 extends ReduxAction<AppState, AppEnvironment> {
 
 class Action7b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     dispatch(Action4());
     dispatch(Action6b());
     dispatch(Action2());
@@ -101,7 +101,7 @@ class Action7b extends ReduxAction<AppState, AppEnvironment> {
 
 class Action8 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.delayed(const Duration(milliseconds: 50));
     dispatch(Action2());
     return AppState.add(state, "8");
@@ -110,7 +110,7 @@ class Action8 extends ReduxAction<AppState, AppEnvironment> {
 
 class Action9 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.delayed(const Duration(milliseconds: 100));
     return AppState.add(state, "9");
   }
@@ -118,7 +118,7 @@ class Action9 extends ReduxAction<AppState, AppEnvironment> {
 
 class Action10a extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action11a());
@@ -129,7 +129,7 @@ class Action10a extends ReduxAction<AppState, AppEnvironment> {
 
 class Action10b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     dispatch(Action1());
     dispatch(Action2());
     dispatch(Action11b());
@@ -140,21 +140,21 @@ class Action10b extends ReduxAction<AppState, AppEnvironment> {
 
 class Action11a extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     throw const UserException("Hello!");
   }
 }
 
 class Action11b extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     throw const UserException("Hello!");
   }
 }
 
 class Action12 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     dispatch(Action13());
     return AppState.add(state, "12");
   }
@@ -162,7 +162,7 @@ class Action12 extends ReduxAction<AppState, AppEnvironment> {
 
 class Action13 extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.delayed(const Duration(milliseconds: 1));
     return AppState.add(state, "13");
   }

--- a/test/sync_async_test.dart
+++ b/test/sync_async_test.dart
@@ -309,7 +309,7 @@ void main() {
 
 class Action1B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     states.add(state);
     return state.copy(state.text + 'B');
   }
@@ -319,7 +319,7 @@ class Action1B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action2B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     states.add(state);
     dispatch(Action2C());
     states.add(state);
@@ -329,7 +329,7 @@ class Action2B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action2C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     return state.copy(state.text + 'C');
   }
 }
@@ -338,7 +338,7 @@ class Action2C extends ReduxAction<AppState, AppEnvironment> {
 
 class Action3B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce({required AppEnvironment environment}) {
+  AppState reduce() {
     states.add(state);
     dispatch(Action3C());
     states.add(state);
@@ -348,7 +348,7 @@ class Action3B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action3C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.sync(() {});
     return state.copy(state.text + 'C');
   }
@@ -358,7 +358,7 @@ class Action3C extends ReduxAction<AppState, AppEnvironment> {
 
 class Action4B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     states.add(state);
     await Future.delayed(const Duration(milliseconds: 100));
     states.add(state);
@@ -372,7 +372,7 @@ class Action4B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action4C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.delayed(const Duration(milliseconds: 50));
     return state.copy(state.text + 'C');
   }
@@ -382,7 +382,7 @@ class Action4C extends ReduxAction<AppState, AppEnvironment> {
 
 class Action5B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     states.add(state);
     await Future.delayed(const Duration(milliseconds: 100));
     states.add(state);
@@ -396,7 +396,7 @@ class Action5B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action5C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.delayed(const Duration(milliseconds: 200));
     return state.copy(state.text + 'C');
   }
@@ -407,7 +407,7 @@ class Action5C extends ReduxAction<AppState, AppEnvironment> {
 /// Returns a COMPLETED Future.
 class Action6B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     print('33333333333');
     states.add(state);
     dispatch(Action6C());
@@ -419,7 +419,7 @@ class Action6B extends ReduxAction<AppState, AppEnvironment> {
 /// Returns an UNCOMPLETED Future.
 class Action6C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.value(null);
     states.add(state);
     print('Action6C.reduce');
@@ -431,7 +431,7 @@ class Action6C extends ReduxAction<AppState, AppEnvironment> {
 
 class Action7B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.value(null);
     states.add(state);
     dispatch(Action7C());
@@ -442,7 +442,7 @@ class Action7B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action7C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     states.add(state);
     await Future.value(null);
     states.add(state);
@@ -454,7 +454,7 @@ class Action7C extends ReduxAction<AppState, AppEnvironment> {
 
 class Action8B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     states.add(state);
     dispatch(Action8C());
     states.add(state);
@@ -466,7 +466,7 @@ class Action8B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action8C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.value(null);
     states.add(state);
     return state.copy(state.text + 'C');
@@ -477,7 +477,7 @@ class Action8C extends ReduxAction<AppState, AppEnvironment> {
 
 class Action9B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     states.add(state);
     await Future.value(null);
     states.add(state);
@@ -491,7 +491,7 @@ class Action9B extends ReduxAction<AppState, AppEnvironment> {
 
 class Action9C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce({required AppEnvironment environment}) async {
+  Future<AppState> reduce() async {
     await Future.value(null);
     states.add(state);
     return state.copy(state.text + 'C');

--- a/test/sync_async_test.dart
+++ b/test/sync_async_test.dart
@@ -34,6 +34,8 @@ class AppState {
   String toString() => text.toString();
 }
 
+class AppEnvironment {}
+
 late List<AppState?> states;
 
 void main() {
@@ -128,10 +130,13 @@ void main() {
       'and no actions are dispatched inside of the reducer. '
       'It acts as a pure function, just like a regular reducer of "vanilla" Redux.', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action1B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action1B]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action1B]));
     expect(states, [AppState('A')]);
     expect(info.state!.text, 'AB');
   });
@@ -143,10 +148,13 @@ void main() {
       'which dispatches another sync action. '
       'They are both executed synchronously.', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action2B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action2B, Action2C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action2B, Action2C]));
     expect(states, [AppState('A'), AppState('AC')]);
     expect(info.state!.text, 'ACB');
   });
@@ -157,10 +165,13 @@ void main() {
       '3) A sync reducer is called, '
       'which dispatches an ASYNC action.', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action3B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action3B, Action3C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action3B, Action3C]));
     expect(states, [AppState('A'), AppState('A')]);
     expect(info.state!.text, 'ABC');
   });
@@ -172,10 +183,13 @@ void main() {
       'which dispatches another ASYNC action. '
       'The second reducer finishes BEFORE the first.', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action4B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action4B, Action4C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action4B, Action4C]));
     expect(states, [AppState('A'), AppState('A'), AppState('A'), AppState('AC')]);
     expect(info.state!.text, 'ACB');
   });
@@ -187,10 +201,13 @@ void main() {
       'which dispatches another ASYNC action. '
       'The second reducer finishes AFTER the first.', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action5B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action5B, Action5C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action5B, Action5C]));
     expect(states, [AppState('A'), AppState('A'), AppState('A'), AppState('A')]);
     expect(info.state!.text, 'ABC');
   });
@@ -204,11 +221,14 @@ void main() {
       'In other words, it will run the reducer later, '
       'when it can actually apply the new state right away.', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action6B());
 
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action6B, Action6C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action6B, Action6C]));
     expect(states, [AppState('A'), AppState('A'), AppState('AB')]);
 
     // State 'C' is lost.
@@ -222,10 +242,13 @@ void main() {
       '7) Test 6 is fixed if the reducer executes an await '
       '(here we try putting it in the beginning).', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action7B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action7B, Action7C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action7B, Action7C]));
     expect(states, [AppState('A'), AppState('A'), AppState('AB'), AppState('AB')]);
     expect(info.state!.text, 'ABC');
   });
@@ -236,10 +259,13 @@ void main() {
       '8) Test 6 is fixed if the reducer executes an await '
       '(here we try putting it in the end).', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action8B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action8B, Action8C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action8B, Action8C]));
     expect(states, [AppState('A'), AppState('A'), AppState('A'), AppState('AB')]);
     expect(info.state!.text, 'ABC');
   });
@@ -250,10 +276,13 @@ void main() {
       '9) Test 6 is fixed if the reducer executes an await '
       '(here we try putting one in the beginning and one in the end).', () async {
     states = [];
-    var storeTester = StoreTester<AppState>(initialState: AppState.initialState());
+    var storeTester = StoreTester<AppState, AppEnvironment>(
+      initialState: AppState.initialState(),
+      environment: AppEnvironment(),
+    );
     expect(storeTester.state.text, 'A');
     storeTester.dispatch(Action9B());
-    TestInfo<AppState?> info = await (storeTester.waitAllUnorderedGetLast([Action9B, Action9C]));
+    TestInfo<AppState?, AppEnvironment> info = await (storeTester.waitAllUnorderedGetLast([Action9B, Action9C]));
     expect(states, [AppState('A'), AppState('A'), AppState('A'), AppState('A'), AppState('AB')]);
     expect(info.state!.text, 'ABC');
   });
@@ -278,9 +307,9 @@ void main() {
 
 // ----------------------------------------------
 
-class Action1B extends ReduxAction<AppState> {
+class Action1B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     states.add(state);
     return state.copy(state.text + 'B');
   }
@@ -288,9 +317,9 @@ class Action1B extends ReduxAction<AppState> {
 
 // ----------------------------------------------
 
-class Action2B extends ReduxAction<AppState> {
+class Action2B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     states.add(state);
     dispatch(Action2C());
     states.add(state);
@@ -298,18 +327,18 @@ class Action2B extends ReduxAction<AppState> {
   }
 }
 
-class Action2C extends ReduxAction<AppState> {
+class Action2C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     return state.copy(state.text + 'C');
   }
 }
 
 // ----------------------------------------------
 
-class Action3B extends ReduxAction<AppState> {
+class Action3B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  AppState reduce() {
+  AppState reduce({required AppEnvironment environment}) {
     states.add(state);
     dispatch(Action3C());
     states.add(state);
@@ -317,9 +346,9 @@ class Action3B extends ReduxAction<AppState> {
   }
 }
 
-class Action3C extends ReduxAction<AppState> {
+class Action3C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.sync(() {});
     return state.copy(state.text + 'C');
   }
@@ -327,9 +356,9 @@ class Action3C extends ReduxAction<AppState> {
 
 // ----------------------------------------------
 
-class Action4B extends ReduxAction<AppState> {
+class Action4B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     states.add(state);
     await Future.delayed(const Duration(milliseconds: 100));
     states.add(state);
@@ -341,9 +370,9 @@ class Action4B extends ReduxAction<AppState> {
   }
 }
 
-class Action4C extends ReduxAction<AppState> {
+class Action4C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.delayed(const Duration(milliseconds: 50));
     return state.copy(state.text + 'C');
   }
@@ -351,9 +380,9 @@ class Action4C extends ReduxAction<AppState> {
 
 // ----------------------------------------------
 
-class Action5B extends ReduxAction<AppState> {
+class Action5B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     states.add(state);
     await Future.delayed(const Duration(milliseconds: 100));
     states.add(state);
@@ -365,9 +394,9 @@ class Action5B extends ReduxAction<AppState> {
   }
 }
 
-class Action5C extends ReduxAction<AppState> {
+class Action5C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.delayed(const Duration(milliseconds: 200));
     return state.copy(state.text + 'C');
   }
@@ -376,9 +405,9 @@ class Action5C extends ReduxAction<AppState> {
 // ----------------------------------------------
 
 /// Returns a COMPLETED Future.
-class Action6B extends ReduxAction<AppState> {
+class Action6B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     print('33333333333');
     states.add(state);
     dispatch(Action6C());
@@ -388,9 +417,9 @@ class Action6B extends ReduxAction<AppState> {
 }
 
 /// Returns an UNCOMPLETED Future.
-class Action6C extends ReduxAction<AppState> {
+class Action6C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.value(null);
     states.add(state);
     print('Action6C.reduce');
@@ -400,9 +429,9 @@ class Action6C extends ReduxAction<AppState> {
 
 // ----------------------------------------------
 
-class Action7B extends ReduxAction<AppState> {
+class Action7B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.value(null);
     states.add(state);
     dispatch(Action7C());
@@ -411,9 +440,9 @@ class Action7B extends ReduxAction<AppState> {
   }
 }
 
-class Action7C extends ReduxAction<AppState> {
+class Action7C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     states.add(state);
     await Future.value(null);
     states.add(state);
@@ -423,9 +452,9 @@ class Action7C extends ReduxAction<AppState> {
 
 // ----------------------------------------------
 
-class Action8B extends ReduxAction<AppState> {
+class Action8B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     states.add(state);
     dispatch(Action8C());
     states.add(state);
@@ -435,9 +464,9 @@ class Action8B extends ReduxAction<AppState> {
   }
 }
 
-class Action8C extends ReduxAction<AppState> {
+class Action8C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.value(null);
     states.add(state);
     return state.copy(state.text + 'C');
@@ -446,9 +475,9 @@ class Action8C extends ReduxAction<AppState> {
 
 // ----------------------------------------------
 
-class Action9B extends ReduxAction<AppState> {
+class Action9B extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     states.add(state);
     await Future.value(null);
     states.add(state);
@@ -460,9 +489,9 @@ class Action9B extends ReduxAction<AppState> {
   }
 }
 
-class Action9C extends ReduxAction<AppState> {
+class Action9C extends ReduxAction<AppState, AppEnvironment> {
   @override
-  Future<AppState> reduce() async {
+  Future<AppState> reduce({required AppEnvironment environment}) async {
     await Future.value(null);
     states.add(state);
     return state.copy(state.text + 'C');

--- a/test/view_model_test.dart
+++ b/test/view_model_test.dart
@@ -27,7 +27,7 @@ class MyObjVmEquals extends VmEquals<MyObjVmEquals> {
 
 // ////////////////////////////////////////////////////////////////////////////
 
-class ViewModel_Deprecated extends BaseModel<List<int>> {
+class ViewModel_Deprecated extends BaseModel<List<int>, int> {
   String name;
   int age;
 

--- a/test/wait_action_test.dart
+++ b/test/wait_action_test.dart
@@ -3,7 +3,7 @@ import 'package:async_redux/src/wait.dart';
 import 'package:async_redux/src/wait_action.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-late Store<AppState> store;
+late Store<AppState, AppEnvironment> store;
 
 ///////////////////////////////////////////////////////////////////////////
 
@@ -14,6 +14,8 @@ class AppState {
 
   AppState copy({Wait? wait}) => AppState(wait: wait ?? this.wait);
 }
+
+class AppEnvironment {}
 
 ///////////////////////////////////////////////////////////////////////////
 
@@ -45,7 +47,10 @@ class MyAction {}
 
 void main() {
   setUp(() async {
-    store = Store<AppState>(initialState: AppState(wait: Wait()));
+    store = Store<AppState, AppEnvironment>(
+      initialState: AppState(wait: Wait()),
+      environment: AppEnvironment(),
+    );
   });
 
   ///////////////////////////////////////////////////////////////////////////
@@ -208,8 +213,11 @@ void main() {
   ///////////////////////////////////////////////////////////////////////////
 
   test("Test compatibility with the Freezed package.", () {
-    Store<AppStateFreezed> freezedStore;
-    freezedStore = Store<AppStateFreezed>(initialState: AppStateFreezed(wait: Wait()));
+    Store<AppStateFreezed, AppEnvironment> freezedStore;
+    freezedStore = Store<AppStateFreezed, AppEnvironment>(
+      initialState: AppStateFreezed(wait: Wait()),
+      environment: AppEnvironment(),
+    );
 
     var action = MyAction();
     expect(freezedStore.state.wait.isWaiting, false);
@@ -227,8 +235,11 @@ void main() {
   ///////////////////////////////////////////////////////////////////////////
 
   test("Test compatibility with the BuiltValue package.", () {
-    Store<AppStateBuiltValue> builtValueStore;
-    builtValueStore = Store<AppStateBuiltValue>(initialState: AppStateBuiltValue(wait: Wait()));
+    Store<AppStateBuiltValue, AppEnvironment> builtValueStore;
+    builtValueStore = Store<AppStateBuiltValue, AppEnvironment>(
+      initialState: AppStateBuiltValue(wait: Wait()),
+      environment: AppEnvironment(),
+    );
 
     var action = MyAction();
     expect(builtValueStore.state.wait.isWaiting, false);
@@ -246,8 +257,11 @@ void main() {
   ///////////////////////////////////////////////////////////////////////////
 
   test("Test compatibility with the BuiltValue package.", () {
-    Store<AppStateFreezed> freezedStore;
-    freezedStore = Store<AppStateFreezed>(initialState: AppStateFreezed(wait: Wait()));
+    Store<AppStateFreezed, AppEnvironment> freezedStore;
+    freezedStore = Store<AppStateFreezed, AppEnvironment>(
+      initialState: AppStateFreezed(wait: Wait()),
+      environment: AppEnvironment(),
+    );
 
     var action = MyAction();
     expect(freezedStore.state.wait.isWaiting, false);


### PR DESCRIPTION
References #107.

Just to explain what I mean, I've created this PR. You're free to decide if it's philosophically the right direction for this project, and if so I'm also happy to clear things up and add more tests.

---

This PR adds a dependency container to `Store` in the form of an "environment", set at the time of the store's creation. It can be accessed by `ReduxAction`s by reading the `environment` field, in the same way as they currently read `state`.

The environment is to be used for attaching dependencies shared by actions. For example, you could pass a `GetIt` instance if you prefer to use it. The advantage of attaching it to the store is clear: a single point of configuration.