### PR TITLE
Removed null-aware '!'

### DIFF
--- a/lib/src/store_connector.dart
+++ b/lib/src/store_connector.dart
@@ -380,7 +380,7 @@ class _StoreStreamListenerState<St, Model> //
     _computeLatestModel();
 
     if ((widget.onInitialBuild != null) && (_latestModel != null)) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         widget.onInitialBuild!(
           mounted ? context : null,
           widget.store,
@@ -539,7 +539,7 @@ class _StoreStreamListenerState<St, Model> //
     _latestModel = vm;
 
     if ((widget.onDidChange != null) && (_latestModel != null)) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         widget.onDidChange!(
           mounted ? context : null,
           widget.store,


### PR DESCRIPTION
Removed null-aware '!' as WidgetsBinding.instance is not nullable in Flutter 2.13.0-0.0