### PR TITLE
Removed null-aware '!'

### DIFF
--- a/lib/src/user_exception_dialog.dart
+++ b/lib/src/user_exception_dialog.dart
@@ -186,7 +186,7 @@ class _UserExceptionDialogState extends State<_UserExceptionDialogWidget> {
     UserException? userException = widget.errorEvent?.consume();
 
     if (userException != null)
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         widget.onShowUserExceptionDialog(context, userException, widget.useLocalContext);
       });
   }


### PR DESCRIPTION
Removed null-aware '!' as WidgetsBinding.instance is not nullable in Flutter 2.13.0-0.0