### PR TITLE
Fix swallowed strack trace

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -455,11 +455,8 @@ class Store<St> {
       else if (identical(processedError, error))
         rethrow;
       // Error was wrapped. Rethrows, but loses stacktrace due to Dart architecture.
-      // See: https://groups.google.com/a/dartlang.org/forum/#!topic/misc/O1OKnYTUcoo
-      // See: https://github.com/dart-lang/sdk/issues/10297
-      // This should be fixed when this issue is solved: https://github.com/dart-lang/sdk/issues/30741
       else
-        throw processedError;
+        Error.throwWithStackTrace(processedError, stackTrace);
     }
     //
      finally {


### PR DESCRIPTION
It seems like that you can now throw an error with a stack trace by using `Error.throwWithStackTrace`.
Tested it in my private project and the stack traces finally get printed out in the console.