### PR TITLE
Fix swallowed stacktrace async

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -508,12 +508,9 @@ class Store<St> {
       // Error was not changed. Rethrows.
       else if (identical(processedError, error))
         rethrow;
-      // Error was wrapped. Rethrows, but loses stacktrace due to Dart architecture.
-      // See: https://groups.google.com/a/dartlang.org/forum/#!topic/misc/O1OKnYTUcoo
-      // See: https://github.com/dart-lang/sdk/issues/10297
-      // This should be fixed when this issue is solved: https://github.com/dart-lang/sdk/issues/30741
+      // Error was wrapped. Throw.
       else
-        throw processedError;
+        Error.throwWithStackTrace(processedError, stackTrace);
     }
     //
      finally {


### PR DESCRIPTION
Same as #127, however, we forgot to do the same thing for async action processing.