### PR TITLE
Fix double reduce of async reducer when WrapReduce is used

### DIFF
--- a/lib/src/wrap_reduce.dart
+++ b/lib/src/wrap_reduce.dart
@@ -76,20 +76,20 @@ abstract class WrapReduce<St> {
       //
       // 2) Async reducer.
       else if (reduce is Future<St?> Function()) {
-        return () => reduce().then((St? state) async {
-              //
-              // The is the state returned by the reducer.
-              St? newState = await reduce();
+        return () async {
+          //
+          // The is the state returned by the reducer.
+          St? newState = await reduce();
 
-              // This is the state right after the reducer returns,
-              // but before it's committed to the store.
-              St oldState = store.state;
+          // This is the state right after the reducer returns,
+          // but before it's committed to the store.
+          St oldState = store.state;
 
-              // If the reducer returned null, or returned the same instance, don't do anything.
-              if (newState == null || identical(store.state, newState)) return newState;
+          // If the reducer returned null, or returned the same instance, don't do anything.
+          if (newState == null || identical(store.state, newState)) return newState;
 
-              return process(oldState: oldState, newState: newState);
-            });
+          return process(oldState: oldState, newState: newState);
+        };
       }
       // Not defined.
       else {

--- a/test/wrap_reduce_test.dart
+++ b/test/wrap_reduce_test.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+@immutable
+class AppState {
+  final int count;
+
+  AppState({this.count = 0});
+
+  AppState copy({int? count}) => AppState(count: count ?? this.count);
+}
+
+class _SyncAction extends ReduxAction<AppState> {
+  static int count = 0;
+
+  @override
+  AppState reduce() {
+    count++;
+    return state.copy(count: state.count + 1);
+  }
+}
+
+class _AsyncAction extends ReduxAction<AppState> {
+  static int count = 0;
+
+  @override
+  Future<AppState> reduce() async {
+    await microtask;
+    count++;
+    return state.copy(count: state.count + 1);
+  }
+}
+
+class _TestWrapReduce extends WrapReduce<AppState> {
+  @override
+  AppState process({required oldState, required newState}) => newState;
+}
+
+void main() {
+  late Store<AppState> store;
+
+  setUp(() async {
+    store = Store<AppState>(
+        initialState: AppState(), wrapReduce: _TestWrapReduce());
+  });
+
+  group(WrapReduce, () {
+    test("Only reduces sync reducer once.", () async {
+      expect(store.state.count, 0);
+      await store.dispatch(_SyncAction());
+      expect(_SyncAction.count, 1);
+      expect(store.state.count, 1);
+    });
+    test("Only reduces async reducer once.", () async {
+      expect(store.state.count, 0);
+      await store.dispatch(_AsyncAction());
+      expect(_AsyncAction.count, 1);
+      expect(store.state.count, 1);
+    });
+  });
+}


### PR DESCRIPTION
`reduce()` for async reducer was called twice in `WrapReduce`, this PR fixes this and adds tests.